### PR TITLE
Fix dyn_dyn_cast! not keeping temporaries live

### DIFF
--- a/dyn-dyn-macros/src/cast.rs
+++ b/dyn-dyn-macros/src/cast.rs
@@ -100,7 +100,7 @@ pub fn dyn_dyn_cast(input: DynDynCastInput) -> TokenStream {
                             r: &(impl ?Sized + #base_primary_trait #(+ #base_markers)*)
                         ) -> &(impl ?Sized + #base_primary_trait #(+ #tgt_markers)*) { r }
 
-                        __dyn_dyn_marker_check(__dyn_dyn_input.__dyn_dyn_deref_typecheck());
+                        __dyn_dyn_marker_check(::dyn_dyn::internal::DerefHelperEnd::typecheck(&__dyn_dyn_input));
                     }
                 )
             } else {
@@ -108,6 +108,9 @@ pub fn dyn_dyn_cast(input: DynDynCastInput) -> TokenStream {
             };
 
             quote!((|__dyn_dyn_input| unsafe {
+                #check_markers
+
+                let __dyn_dyn_input = ::dyn_dyn::internal::DerefHelperEnd::end(__dyn_dyn_input);
                 if true {
                     ::dyn_dyn::internal::#try_downcast::<dyn #base_primary_trait, dyn #tgt_primary_trait, _>(__dyn_dyn_input, |p| p as *mut (dyn #tgt_primary_trait #(+ #tgt_markers)*))
                 } else {
@@ -120,20 +123,12 @@ pub fn dyn_dyn_cast(input: DynDynCastInput) -> TokenStream {
                     Some(__dyn_dyn_constrain_lifetime(__dyn_dyn_input.0))
                 }
             })({
-                let __dyn_dyn_input = ::dyn_dyn::internal::#deref_helper::<dyn #base_primary_trait, _>::new(#val);
+                use ::dyn_dyn::internal::DerefHelperT;
 
-                {
-                    use ::dyn_dyn::internal::DerefHelperT;
-
-                    let __dyn_dyn_input = __dyn_dyn_input
-                        .__dyn_dyn_check_ref()
-                        .__dyn_dyn_check_trait()
-                        .__dyn_dyn_check_deref();
-
-                    #check_markers
-
-                    __dyn_dyn_input.__dyn_dyn_deref()
-                }
+                ::dyn_dyn::internal::#deref_helper::<dyn #base_primary_trait, _>::new(#val)
+                    .__dyn_dyn_check_ref()
+                    .__dyn_dyn_check_trait()
+                    .__dyn_dyn_check_deref()
             }))
         }
         Err((span, err)) => {

--- a/dyn-dyn/tests/basics.rs
+++ b/dyn-dyn/tests/basics.rs
@@ -204,3 +204,23 @@ fn test_multi_base() {
     assert!(dyn_dyn_cast!(BaseB => TraitA, &TestStruct as &dyn BaseB).is_none());
     assert!(dyn_dyn_cast!(BaseB => TraitB, &TestStruct as &dyn BaseB).is_some());
 }
+
+#[test]
+fn test_temporaries_extended() {
+    #[dyn_dyn_base]
+    trait Base {}
+    trait Trait {}
+
+    struct TestStruct;
+
+    #[dyn_dyn_derived(Trait)]
+    impl Base for TestStruct {}
+    impl Trait for TestStruct {}
+
+    fn return_temporary() -> TestStruct {
+        TestStruct
+    }
+
+    assert!(dyn_dyn_cast!(Base => Trait, &return_temporary() as &dyn Base).is_some());
+    assert!(dyn_dyn_cast!(mut Base => Trait, &mut return_temporary() as &mut dyn Base).is_some());
+}


### PR DESCRIPTION
The previous implementation of the dyn_dyn_cast! macro was not properly
keeping any temporaries used in the computation of the value to be
downcast live until the end of the current statement. This would require
the caller to add let declarations to ensure these temporaries live long
enough, which was quite annoying.

This has now been corrected by ensuring that the input from the user is
used as the input to the closure without ever being put into a let
declaration. This did also necessitate some changes to how the
resolution-based specialization worked, since rustc has trouble
performing type-checking in this case unless a fully-qualified method
name is used to complete the dereference.