### PR TITLE
Disable GitHub Actions on push for feature branches

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,10 @@
 name: Tests
-on: [push, pull_request]
-
+on:
+  push:
+    branches:
+      - 'master'
+      - 'release/**'
+  pull_request:
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Previously, GitHub actions were enabled for push on all branches and for
all PRs. This was causing duplicate runs for feature branches, since
they'd be run both when pushed and when a PR was opened. To correct
this, GitHub actions are now disabled on push for feature branches.