### PR TITLE
Rework the DynDyn trait to allow downcasting of smart pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ fn main() {
 
     assert!(dyn_dyn_cast!(BaseTrait => ExposedTrait, &s).is_some());
     assert!(dyn_dyn_cast!(mut BaseTrait => ExposedTrait, &mut s).is_some());
+    assert!(dyn_dyn_cast!(move BaseTrait => ExposedTrait, Box::new(s)).is_some());
 }
 ```
 
@@ -38,7 +39,7 @@ This works for any auto traits, including those declared by other crates using t
 
 ## Limitations
 
-Currently, `dyn-dyn` only works in nightly versions of Rust due to its use of the unstable `ptr_metadata` and `unsize` features, as well as due to its use of several standard library features in `const` contexts.
+Currently, `dyn-dyn` only works in nightly versions of Rust due to its use of the unstable `generic_associated_types`, `ptr_metadata`, and `unsize` features, as well as due to its use of several standard library features in `const` contexts.
 
 Due to limitations of `TypeId`, `dyn-dyn` can only currently work with types and traits that are `'static`.
 

--- a/dyn-dyn-macros/src/cast.rs
+++ b/dyn-dyn-macros/src/cast.rs
@@ -116,13 +116,26 @@ pub fn dyn_dyn_cast(input: DynDynCastInput) -> TokenStream {
                 quote!()
             };
 
+            let cast_metadata = if !tgt_markers.is_empty() {
+                quote! {
+                    let __dyn_dyn_metadata = ::dyn_dyn::internal::cast_metadata::<
+                        dyn #tgt_primary_trait, dyn #tgt_primary_trait #(+ #tgt_markers)*
+                    >(__dyn_dyn_metadata, |__dyn_dyn_ptr| __dyn_dyn_ptr as *mut (dyn #tgt_primary_trait #(+ #tgt_markers)*));
+                }
+            } else {
+                quote!()
+            };
+
             quote!((|__dyn_dyn_input| unsafe {
                 #check_markers
 
                 let __dyn_dyn_table = ::dyn_dyn::internal::DerefHelperEnd::<dyn #base_primary_trait>::get_dyn_dyn_table(&__dyn_dyn_input);
                 if true {
                     __dyn_dyn_table.find::<dyn #tgt_primary_trait>().map(|__dyn_dyn_metadata| {
-                        ::dyn_dyn::internal::DerefHelperEnd::<dyn #base_primary_trait>::downcast_unchecked::<dyn #tgt_primary_trait #(+ #tgt_markers)*>(__dyn_dyn_input, __dyn_dyn_metadata)
+                        #cast_metadata
+                        ::dyn_dyn::internal::DerefHelperEnd::<dyn #base_primary_trait>::downcast_unchecked::<
+                            dyn #tgt_primary_trait #(+ #tgt_markers)*
+                        >(__dyn_dyn_input, __dyn_dyn_metadata)
                     })
                 } else {
                     fn __dyn_dyn_constrain_lifetime<

--- a/dyn-dyn/src/dyn_trait.rs
+++ b/dyn-dyn/src/dyn_trait.rs
@@ -69,14 +69,14 @@ impl PartialEq for DynInfo {
 
 impl Eq for DynInfo {}
 
-pub trait DynTrait: private::Sealed + 'static {
+pub trait DynTrait: private::Sealed {
     fn ptr_into_parts(ptr: NonNull<Self>) -> (NonNull<()>, AnyDynMetadata);
     unsafe fn ptr_from_parts(data: NonNull<()>, meta: AnyDynMetadata) -> NonNull<Self>;
 
     unsafe fn meta_for_ty<U, F: ~const FnOnce(*const U) -> *const Self>(f: F) -> AnyDynMetadata;
 }
 
-impl<T: Pointee<Metadata = DynMetadata<T>> + ?Sized + 'static> const DynTrait for T {
+impl<T: Pointee<Metadata = DynMetadata<T>> + ?Sized> const DynTrait for T {
     fn ptr_into_parts(ptr: NonNull<Self>) -> (NonNull<()>, AnyDynMetadata) {
         (ptr.cast(), ptr::metadata(ptr.as_ptr()).into())
     }
@@ -95,5 +95,5 @@ mod private {
 
     pub trait Sealed {}
 
-    impl<T: Pointee<Metadata = DynMetadata<T>> + ?Sized + 'static> Sealed for T {}
+    impl<T: Pointee<Metadata = DynMetadata<T>> + ?Sized> Sealed for T {}
 }

--- a/dyn-dyn/src/fat.rs
+++ b/dyn-dyn/src/fat.rs
@@ -1,4 +1,4 @@
-use crate::{DynDyn, DynDynBase, DynDynMut, DynDynTable};
+use crate::{AnyDynMetadata, DowncastUnchecked, DynDynBase, DynDynTable, DynTrait, GetDynDynTable};
 use core::cmp::Ordering;
 use core::fmt::{self, Display, Pointer};
 use core::hash::{Hash, Hasher};
@@ -14,30 +14,20 @@ use stable_deref_trait::{CloneStableDeref, StableDeref};
 /// cached table will be used for trait object metadata lookups. This effectively avoids the overhead of the repeated indirect calls to
 /// retrieve the table at the cost of increasing the size of the pointer to the object.
 #[derive(Debug)]
-pub struct DynDynFat<B: ?Sized + DynDynBase, P: Deref>
-where
-    P::Target: Unsize<B>,
-{
+pub struct DynDynFat<B: ?Sized + DynDynBase, P> {
     ptr: P,
     table: DynDynTable,
     _base: PhantomData<fn(B) -> B>,
 }
 
-impl<B: ?Sized + DynDynBase, P: Deref> DynDynFat<B, P>
-where
-    P::Target: Unsize<B>,
-{
-    /// Creates a new fat pointer wrapping the provided pointer. This will immediately dereference the provided pointer to get the
-    /// referenced object's [`DynDynTable`].
+impl<B: ?Sized + DynDynBase, P: GetDynDynTable<B>> DynDynFat<B, P> {
+    /// Creates a new fat pointer with the provided pointer and [`DynDynTable`].
     ///
     /// # Safety
     ///
-    /// The caller must guarantee that as long as this fat pointer is live, `ptr` will dereference to an object of the same concrete type.
-    /// Additionally, if this fat pointer is cloned, the same guarantee must apply to the result of `ptr.clone()` for the lifespan of the
-    /// cloned fat pointer.
-    pub unsafe fn new_unchecked(ptr: P) -> Self {
-        let table = DynDyn::<B>::deref_dyn_dyn(&&*ptr).1;
-
+    /// `table` must refer to the same table as a table that would be returned by calling [`GetDynDynTable::get_dyn_dyn_table`] on `ptr` at
+    /// the time that this function is called.
+    pub unsafe fn new_unchecked(ptr: P, table: DynDynTable) -> Self {
         DynDynFat {
             ptr,
             table,
@@ -45,6 +35,30 @@ where
         }
     }
 
+    /// Creates a new fat pointer wrapping the provided pointer. This will immediately get the pointer's [`DynDynTable`] by calling
+    /// [`GetDynDynTable<B>::get_dyn_dyn_table`] and cache it for future use.
+    pub fn new(ptr: P) -> Self {
+        let table = ptr.get_dyn_dyn_table();
+
+        // SAFETY: This table was just retrieved by calling get_dyn_dyn_table, so it's valid
+        unsafe { Self::new_unchecked(ptr, table) }
+    }
+
+    /// Gets the [`DynDynTable`] of the object referenced by a fat pointer without dereferencing it.
+    pub fn get_dyn_dyn_table(ptr: &Self) -> DynDynTable {
+        ptr.table
+    }
+
+    /// Unwraps a fat pointer, returning the pointer originally used to construct it.
+    pub fn unwrap(ptr: Self) -> P {
+        ptr.ptr
+    }
+}
+
+impl<B: ?Sized + DynDynBase, P: Deref> DynDynFat<B, P>
+where
+    P::Target: Unsize<B>,
+{
     /// Dereferences a fat pointer to produce a fat pointer with a reference.
     pub fn deref_fat(ptr: &Self) -> DynDynFat<B, &P::Target> {
         DynDynFat {
@@ -52,16 +66,6 @@ where
             table: ptr.table,
             _base: PhantomData,
         }
-    }
-
-    /// Unwraps a fat pointer, returning the pointer originally used to construct it.
-    pub fn unwrap(ptr: Self) -> P {
-        ptr.ptr
-    }
-
-    /// Gets the [`DynDynTable`] of the object referenced by a fat pointer without dereferencing it.
-    pub fn get_dyn_dyn_table(ptr: &Self) -> DynDynTable {
-        ptr.table
     }
 }
 
@@ -79,23 +83,7 @@ where
     }
 }
 
-impl<B: ?Sized + DynDynBase, P: StableDeref> DynDynFat<B, P>
-where
-    P::Target: Unsize<B>,
-{
-    /// Creates a new fat pointer wrapping the provided pointer. This will immediately dereference the provided pointer to get the
-    /// referenced object's [`DynDynTable`].
-    pub fn new(ptr: P) -> Self {
-        // SAFETY: Since the provided pointer implements StableDeref, it must always dereference to the same object whose concrete type
-        //         cannot change for the life of this fat pointer.
-        unsafe { Self::new_unchecked(ptr) }
-    }
-}
-
-impl<B: ?Sized + DynDynBase, P: Deref + Clone> DynDynFat<B, P>
-where
-    P::Target: Unsize<B>,
-{
+impl<B: ?Sized + DynDynBase, P: Clone> DynDynFat<B, P> {
     /// Clones a fat pointer without verifying that the [`DynDynTable`] held by the new fat pointer is applicable to the cloned pointer.
     ///
     /// # Safety
@@ -111,10 +99,31 @@ where
     }
 }
 
-impl<B: ?Sized + DynDynBase, P: Deref> Deref for DynDynFat<B, P>
-where
-    P::Target: Unsize<B>,
+// SAFETY: The table returned by this implementation was retrieved from the pointer at the time the DynDynFat was created and DynDynFat does
+//         not expose any way to mutate the pointer itself. Additionally, DynTarget is simply passed through from the pointer, so it must be
+//         valid for that pointer.
+unsafe impl<B: ?Sized + DynDynBase, P: GetDynDynTable<B>> GetDynDynTable<B> for DynDynFat<B, P> {
+    type DynTarget = P::DynTarget;
+
+    fn get_dyn_dyn_table(&self) -> DynDynTable {
+        self.table
+    }
+}
+
+impl<'a, B: ?Sized + DynDynBase, P: DowncastUnchecked<'a, B> + 'a> DowncastUnchecked<'a, B>
+    for DynDynFat<B, P>
 {
+    type DowncastResult<D: ?Sized + 'a> = <P as DowncastUnchecked<'a, B>>::DowncastResult<D>;
+
+    unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(
+        self,
+        metadata: AnyDynMetadata,
+    ) -> Self::DowncastResult<D> {
+        self.ptr.downcast_unchecked(metadata)
+    }
+}
+
+impl<B: ?Sized + DynDynBase, P: Deref> Deref for DynDynFat<B, P> {
     type Target = P::Target;
 
     fn deref(&self) -> &Self::Target {
@@ -122,60 +131,29 @@ where
     }
 }
 
-// SAFETY: All APIs for creating a DynDynFat either guarantee stable deref or are unsafe and require the caller to assert that this
-//         DynDynFat's table meets the requirements for this impl
-unsafe impl<B: ?Sized + DynDynBase, P: Deref> DynDyn<B> for DynDynFat<B, P>
-where
-    P::Target: Unsize<B>,
-{
-    fn deref_dyn_dyn(&self) -> (&B, DynDynTable) {
-        (&*self.ptr, self.table)
-    }
-}
-
-// SAFETY: All APIs for creating a DynDynFat either guarantee stable deref or are unsafe and require the caller to assert that this
-//         DynDynFat's table meets the requirements for this impl
-unsafe impl<B: ?Sized + DynDynBase, P: DerefMut> DynDynMut<B> for DynDynFat<B, P>
-where
-    P::Target: Unsize<B>,
-{
-    fn deref_mut_dyn_dyn(&mut self) -> (&mut B, DynDynTable) {
-        (&mut *self.ptr, self.table)
-    }
-}
-
 // SAFETY: DynDynFat implements deref() by dereferencing the wrapped pointer, so if that pointer is StableDeref then so is the DynDynFat
-unsafe impl<B: ?Sized + DynDynBase, P: StableDeref> StableDeref for DynDynFat<B, P> where
-    P::Target: Unsize<B>
-{
-}
+unsafe impl<B: ?Sized + DynDynBase, P: StableDeref> StableDeref for DynDynFat<B, P> {}
 
 // SAFETY: DynDynFat implements clone() by cloning the wrapped pointer and implements deref() by dereferencing the wrapped pointer, so if
 //         that pointer is CloneStableDeref then so is the DynDynFat
-unsafe impl<B: ?Sized + DynDynBase, P: CloneStableDeref> CloneStableDeref for DynDynFat<B, P> where
-    P::Target: Unsize<B>
+unsafe impl<B: ?Sized + DynDynBase, P: CloneStableDeref + GetDynDynTable<B>> CloneStableDeref
+    for DynDynFat<B, P>
 {
 }
 
-impl<B: ?Sized + DynDynBase, P: DerefMut> DerefMut for DynDynFat<B, P>
-where
-    P::Target: Unsize<B>,
-{
+impl<B: ?Sized + DynDynBase, P: DerefMut> DerefMut for DynDynFat<B, P> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.ptr.deref_mut()
     }
 }
 
-impl<B: ?Sized + DynDynBase, P: Deref + Clone> Clone for DynDynFat<B, P>
-where
-    P::Target: Unsize<B>,
-{
+impl<B: ?Sized + DynDynBase, P: Deref + Clone + GetDynDynTable<B>> Clone for DynDynFat<B, P> {
     fn clone(&self) -> Self {
         let ptr = self.ptr.clone();
         let table = if ptr::eq(ptr.deref(), self.ptr.deref()) {
             self.table
         } else {
-            DynDyn::<B>::deref_dyn_dyn(&&*ptr).1
+            <P as GetDynDynTable<B>>::get_dyn_dyn_table(&ptr)
         };
 
         DynDynFat {
@@ -186,30 +164,24 @@ where
     }
 }
 
-impl<B: ?Sized + DynDynBase, P: Deref + Copy> Copy for DynDynFat<B, P> where P::Target: Unsize<B> {}
-
-impl<B: ?Sized + DynDynBase, P: StableDeref + Default> Default for DynDynFat<B, P>
-where
-    P::Target: Unsize<B>,
+impl<B: ?Sized + DynDynBase, P: Deref + Copy + GetDynDynTable<B>> Copy for DynDynFat<B, P> where
+    P::Target: Unsize<B>
 {
+}
+
+impl<B: ?Sized + DynDynBase, P: GetDynDynTable<B> + Default> Default for DynDynFat<B, P> {
     fn default() -> Self {
         DynDynFat::new(Default::default())
     }
 }
 
-impl<B: ?Sized + DynDynBase, P: StableDeref> From<P> for DynDynFat<B, P>
-where
-    P::Target: Unsize<B>,
-{
+impl<B: ?Sized + DynDynBase, P: GetDynDynTable<B>> From<P> for DynDynFat<B, P> {
     fn from(ptr: P) -> Self {
         DynDynFat::new(ptr)
     }
 }
 
-impl<B: ?Sized + DynDynBase, P: Deref> AsRef<P> for DynDynFat<B, P>
-where
-    P::Target: Unsize<B>,
-{
+impl<B: ?Sized + DynDynBase, P: Deref> AsRef<P> for DynDynFat<B, P> {
     fn as_ref(&self) -> &P {
         &self.ptr
     }
@@ -265,19 +237,13 @@ where
 {
 }
 
-impl<B: ?Sized + DynDynBase, P: Deref + Display> Display for DynDynFat<B, P>
-where
-    P::Target: Unsize<B>,
-{
+impl<B: ?Sized + DynDynBase, P: Display> Display for DynDynFat<B, P> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.ptr)
     }
 }
 
-impl<B: ?Sized + DynDynBase, P: Deref + Pointer> Pointer for DynDynFat<B, P>
-where
-    P::Target: Unsize<B>,
-{
+impl<B: ?Sized + DynDynBase, P: Pointer> Pointer for DynDynFat<B, P> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:p}", self.ptr)
     }

--- a/dyn-dyn/src/fat.rs
+++ b/dyn-dyn/src/fat.rs
@@ -1,11 +1,11 @@
-use crate::{AnyDynMetadata, DowncastUnchecked, DynDynBase, DynDynTable, DynTrait, GetDynDynTable};
+use crate::{DowncastUnchecked, DynDynBase, DynDynTable, DynTrait, GetDynDynTable};
 use core::cmp::Ordering;
 use core::fmt::{self, Display, Pointer};
 use core::hash::{Hash, Hasher};
 use core::marker::{PhantomData, Unsize};
 use core::ops::CoerceUnsized;
 use core::ops::{Deref, DerefMut};
-use core::ptr;
+use core::ptr::{self, DynMetadata};
 use stable_deref_trait::{CloneStableDeref, StableDeref};
 
 /// A fat pointer to an object that can be downcast via the base trait object `B`.
@@ -117,7 +117,7 @@ impl<'a, B: ?Sized + DynDynBase, P: DowncastUnchecked<'a, B> + 'a> DowncastUnche
 
     unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(
         self,
-        metadata: AnyDynMetadata,
+        metadata: DynMetadata<D>,
     ) -> Self::DowncastResult<D> {
         self.ptr.downcast_unchecked(metadata)
     }

--- a/dyn-dyn/src/internal.rs
+++ b/dyn-dyn/src/internal.rs
@@ -1,7 +1,10 @@
-use crate::{DynDyn, DynDynMut, DynDynTable, DynTrait};
+use crate::{
+    AnyDynMetadata, DowncastUnchecked, DynDyn, DynDynRef, DynDynRefMut, DynDynTable, DynTrait,
+    GetDynDynTable,
+};
 use core::marker::{PhantomData, Unsize};
 use core::ops::{Deref, DerefMut};
-use core::ptr::NonNull;
+use stable_deref_trait::StableDeref;
 
 #[allow(clippy::missing_safety_doc)] // This module is marked doc(hidden)
 pub unsafe trait DynDynDerived<B: ?Sized + DynDynBase> {
@@ -13,44 +16,20 @@ pub unsafe trait DynDynBase {
     fn get_dyn_dyn_table(&self) -> DynDynTable;
 }
 
-// In order to select the proper method of getting the base reference and table when using the dyn_dyn_cast! macro, we use some method
-// resolution tricks to simulate specialization. These dummy trait methods will be invoked by the macro if the bounds on the corresponding
-// impl block on DerefHelper aren't matched. This means that after calling all of them in succession, we end up with an object having a
-// __dyn_dyn_deref() method that does the thing we want. The order of resolution we want is:
-//
-//   - Any reference &T where T implements B
-//   - Any reference &T where T implements DynDyn<B>
-//   - Any reference &T where T implements Deref which produces a reference to a type that implements B
-pub trait DerefHelperT {
-    fn __dyn_dyn_check_ref(self) -> Self;
-    fn __dyn_dyn_check_trait(self) -> Self;
-    fn __dyn_dyn_check_deref(self) -> Self;
-}
-
-pub trait DerefHelperEnd {
-    type BaseRef;
-    type ActualDeref: ?Sized;
-
-    fn end(self) -> (Self::BaseRef, DynDynTable);
-    fn typecheck(&self) -> &Self::ActualDeref {
-        panic!("this method is only meant to be used for typechecking and should never be called")
-    }
-}
-
-pub struct DerefHelper<'a, B: ?Sized + DynDynBase, T: ?Sized>(&'a T, PhantomData<fn(B) -> B>);
-
-impl<'a, B: ?Sized + DynDynBase, T: ?Sized> DerefHelper<'a, B, T> {
-    pub fn new(val: &'a T) -> Self {
-        Self(val, PhantomData)
-    }
-}
-
-impl<'a, B: ?Sized + DynDynBase, T: ?Sized> DerefHelperT for DerefHelper<'a, B, T> {
-    fn __dyn_dyn_check_ref(self) -> Self {
+pub trait DerefHelperT: Sized {
+    fn __dyn_dyn_check_dyn_dyn(self) -> Self {
         self
     }
 
-    fn __dyn_dyn_check_trait(self) -> Self {
+    fn __dyn_dyn_check_ref_mut_dyn_dyn(self) -> Self {
+        self
+    }
+
+    fn __dyn_dyn_check_ref_dyn_dyn(self) -> Self {
+        self
+    }
+
+    fn __dyn_dyn_check_deref_mut(self) -> Self {
         self
     }
 
@@ -59,213 +38,112 @@ impl<'a, B: ?Sized + DynDynBase, T: ?Sized> DerefHelperT for DerefHelper<'a, B, 
     }
 }
 
-impl<'a, B: ?Sized + DynDynBase, T: ?Sized + Unsize<B>> DerefHelper<'a, B, T> {
-    pub fn __dyn_dyn_check_ref(self) -> DerefHelperRef<'a, B, T> {
-        DerefHelperRef(self.0, self.1)
+pub trait DerefHelperEnd<'a, B: ?Sized + DynDynBase> {
+    type Inner: DynDyn<'a, B>;
+
+    fn get_dyn_dyn_table(&self) -> DynDynTable;
+    unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(
+        self,
+        metadata: AnyDynMetadata,
+    ) -> <Self::Inner as DowncastUnchecked<'a, B>>::DowncastResult<D>;
+    fn unwrap(self) -> Self::Inner;
+    fn typecheck(&self) -> &<Self::Inner as GetDynDynTable<B>>::DynTarget {
+        panic!("this method is only meant to be used for typechecking");
     }
 }
 
-impl<'a, B: ?Sized + DynDynBase, T: ?Sized + DynDyn<B>> DerefHelper<'a, B, T> {
-    pub fn __dyn_dyn_check_trait(self) -> DerefHelperDynDyn<'a, B, T> {
-        DerefHelperDynDyn(self.0, self.1)
+pub struct DerefHelper<B: ?Sized + DynDynBase, T>(T, PhantomData<fn(B) -> B>);
+
+impl<B: ?Sized + DynDynBase, T> DerefHelperT for DerefHelper<B, T> {}
+
+impl<B: ?Sized + DynDynBase, T> DerefHelper<B, T> {
+    pub fn new_move(val: T) -> Self {
+        DerefHelper(val, PhantomData)
     }
 }
 
-// This impl should never actually be used, since __dyn_dyn_check_trait should always result in a DerefHelperTrait with these trait bounds.
-// This impl is only actually here so that we get a reasonable error message if all the checks fail.
-impl<'a, B: ?Sized + DynDynBase + 'a, T: ?Sized + DynDyn<B>> DerefHelperEnd
-    for DerefHelper<'a, B, T>
-{
-    type BaseRef = &'a B;
-    type ActualDeref = &'a T;
-
-    fn end(self) -> (&'a B, DynDynTable) {
-        panic!("this method should never be called!")
+impl<'a, B: ?Sized + DynDynBase, T: ?Sized> DerefHelper<B, &'a T> {
+    pub fn new_ref(val: &'a T) -> Self {
+        DerefHelper(val, PhantomData)
     }
 }
 
-impl<'a, B: ?Sized + DynDynBase, T: ?Sized + Deref> DerefHelper<'a, B, T>
+impl<'a, B: ?Sized + DynDynBase, T: ?Sized> DerefHelper<B, &'a mut T> {
+    pub fn new_mut(val: &'a mut T) -> Self {
+        DerefHelper(val, PhantomData)
+    }
+}
+
+impl<'a, B: ?Sized + DynDynBase, T: DynDyn<'a, B>> DerefHelper<B, T> {
+    pub fn __dyn_dyn_check_dyn_dyn(self) -> DerefHelperResolved<'a, B, T> {
+        DerefHelperResolved(self.0, self.1, PhantomData)
+    }
+}
+
+impl<'a, B: ?Sized + DynDynBase, T: DynDyn<'a, B> + StableDeref + DerefMut>
+    DerefHelper<B, &'a mut T>
 where
     T::Target: Unsize<B>,
 {
-    pub fn __dyn_dyn_check_deref(self) -> DerefHelperRef<'a, B, T::Target> {
-        DerefHelperRef(&**self.0, self.1)
+    pub fn __dyn_dyn_check_ref_mut_dyn_dyn(
+        self,
+    ) -> DerefHelperResolved<'a, B, DynDynRefMut<'a, B, T>> {
+        DerefHelperResolved(DynDynRefMut::new(self.0), self.1, PhantomData)
     }
 }
 
-pub struct DerefHelperRef<'a, B: ?Sized + DynDynBase, T: ?Sized + Unsize<B>>(
-    &'a T,
-    PhantomData<fn(B) -> B>,
-);
-
-impl<'a, B: ?Sized + DynDynBase, T: ?Sized + Unsize<B>> DerefHelperRef<'a, B, T> {
-    pub fn __dyn_dyn_check_trait(self) -> Self {
-        self
-    }
-
-    pub fn __dyn_dyn_check_deref(self) -> Self {
-        self
-    }
-}
-
-impl<'a, B: ?Sized + DynDynBase + 'a, T: ?Sized + Unsize<B>> DerefHelperEnd
-    for DerefHelperRef<'a, B, T>
-{
-    type BaseRef = &'a B;
-    type ActualDeref = T;
-
-    fn end(self) -> (&'a B, DynDynTable) {
-        let (_, table) = DynDyn::<B>::deref_dyn_dyn(&self.0);
-        (self.0, table)
-    }
-}
-
-pub struct DerefHelperDynDyn<'a, B: ?Sized + DynDynBase, T: ?Sized + DynDyn<B>>(
-    &'a T,
-    PhantomData<fn(B) -> B>,
-);
-
-impl<'a, B: ?Sized + DynDynBase, T: ?Sized + DynDyn<B>> DerefHelperDynDyn<'a, B, T> {
-    pub fn __dyn_dyn_check_deref(self) -> Self {
-        self
-    }
-}
-
-impl<'a, B: ?Sized + DynDynBase + 'a, T: ?Sized + DynDyn<B>> DerefHelperEnd
-    for DerefHelperDynDyn<'a, B, T>
-{
-    type BaseRef = &'a B;
-    type ActualDeref = T::Target;
-
-    fn end(self) -> (&'a B, DynDynTable) {
-        DynDyn::<B>::deref_dyn_dyn(self.0)
-    }
-}
-
-#[inline(always)]
-pub unsafe fn try_downcast<B: ?Sized + DynDynBase, D: ?Sized + DynTrait, R: ?Sized>(
-    (ptr, table): (&B, DynDynTable),
-    f: impl Fn(*mut D) -> *mut R,
-) -> Option<&R> {
-    table
-        .find_dyn(NonNull::from(ptr).cast())
-        .map(|p| &*f(p.as_ptr()))
-}
-
-pub struct DerefMutHelper<'a, B: ?Sized + DynDynBase, T: ?Sized>(
-    &'a mut T,
-    PhantomData<fn(B) -> B>,
-);
-
-impl<'a, B: ?Sized + DynDynBase, T: ?Sized> DerefMutHelper<'a, B, T> {
-    pub fn new(val: &'a mut T) -> Self {
-        Self(val, PhantomData)
-    }
-}
-
-impl<'a, B: ?Sized + DynDynBase, T: ?Sized> DerefHelperT for DerefMutHelper<'a, B, T> {
-    fn __dyn_dyn_check_ref(self) -> Self {
-        self
-    }
-
-    fn __dyn_dyn_check_trait(self) -> Self {
-        self
-    }
-
-    fn __dyn_dyn_check_deref(self) -> Self {
-        self
-    }
-}
-
-impl<'a, B: ?Sized + DynDynBase, T: ?Sized + Unsize<B>> DerefMutHelper<'a, B, T> {
-    pub fn __dyn_dyn_check_ref(self) -> DerefMutHelperRef<'a, B, T> {
-        DerefMutHelperRef(self.0, self.1)
-    }
-}
-
-impl<'a, B: ?Sized + DynDynBase, T: ?Sized + DynDynMut<B>> DerefMutHelper<'a, B, T> {
-    pub fn __dyn_dyn_check_trait(self) -> DerefMutHelperDynDyn<'a, B, T> {
-        DerefMutHelperDynDyn(self.0, self.1)
-    }
-}
-
-// This impl should never actually be used, since __dyn_dyn_check_trait should always result in a DerefHelperTrait with these trait bounds.
-// This impl is only actually here so that we get a reasonable error message if all the checks fail.
-impl<'a, B: ?Sized + DynDynBase + 'a, T: ?Sized + DynDynMut<B>> DerefHelperEnd
-    for DerefMutHelper<'a, B, T>
-{
-    type BaseRef = &'a mut B;
-    type ActualDeref = &'a T;
-
-    fn end(self) -> (&'a mut B, DynDynTable) {
-        panic!("this method should never be called!")
-    }
-}
-
-impl<'a, B: ?Sized + DynDynBase, T: ?Sized + DerefMut> DerefMutHelper<'a, B, T>
+impl<'a, B: ?Sized + DynDynBase, T: DynDyn<'a, B> + StableDeref> DerefHelper<B, &'a T>
 where
     T::Target: Unsize<B>,
 {
-    pub fn __dyn_dyn_check_deref(self) -> DerefMutHelperRef<'a, B, T::Target> {
-        DerefMutHelperRef(&mut **self.0, self.1)
+    pub fn __dyn_dyn_check_ref_dyn_dyn(self) -> DerefHelperResolved<'a, B, DynDynRef<'a, B, T>> {
+        DerefHelperResolved(DynDynRef::new(self.0), self.1, PhantomData)
     }
 }
 
-pub struct DerefMutHelperRef<'a, B: ?Sized + DynDynBase, T: ?Sized + Unsize<B>>(
-    &'a mut T,
+impl<'a, B: ?Sized + DynDynBase, T: DerefMut> DerefHelper<B, &'a mut T>
+where
+    T::Target: Unsize<B>,
+{
+    pub fn __dyn_dyn_check_deref_mut(self) -> DerefHelperResolved<'a, B, &'a mut T::Target> {
+        DerefHelperResolved(&mut **self.0, self.1, PhantomData)
+    }
+}
+
+impl<'a, B: ?Sized + DynDynBase, T: Deref> DerefHelper<B, &'a T>
+where
+    T::Target: Unsize<B>,
+{
+    pub fn __dyn_dyn_check_deref(self) -> DerefHelperResolved<'a, B, &'a T::Target> {
+        DerefHelperResolved(&**self.0, self.1, PhantomData)
+    }
+}
+
+pub struct DerefHelperResolved<'a, B: ?Sized + DynDynBase, T: DynDyn<'a, B>>(
+    T,
     PhantomData<fn(B) -> B>,
+    PhantomData<&'a ()>,
 );
 
-impl<'a, B: ?Sized + DynDynBase, T: ?Sized + Unsize<B>> DerefMutHelperRef<'a, B, T> {
-    pub fn __dyn_dyn_check_trait(self) -> Self {
-        self
-    }
+impl<'a, B: ?Sized + DynDynBase, T: DynDyn<'a, B>> DerefHelperT for DerefHelperResolved<'a, B, T> {}
 
-    pub fn __dyn_dyn_check_deref(self) -> Self {
-        self
-    }
-}
-
-impl<'a, B: ?Sized + DynDynBase + 'a, T: ?Sized + Unsize<B>> DerefHelperEnd
-    for DerefMutHelperRef<'a, B, T>
+impl<'a, B: ?Sized + DynDynBase, T: DynDyn<'a, B>> DerefHelperEnd<'a, B>
+    for DerefHelperResolved<'a, B, T>
 {
-    type BaseRef = &'a mut B;
-    type ActualDeref = T;
+    type Inner = T;
 
-    fn end(mut self) -> (&'a mut B, DynDynTable) {
-        let (_, table) = DynDynMut::<B>::deref_mut_dyn_dyn(&mut self.0);
-        (self.0, table)
+    fn get_dyn_dyn_table(&self) -> DynDynTable {
+        self.0.get_dyn_dyn_table()
     }
-}
 
-pub struct DerefMutHelperDynDyn<'a, B: ?Sized + DynDynBase, T: ?Sized + DynDynMut<B>>(
-    &'a mut T,
-    PhantomData<fn(B) -> B>,
-);
-
-impl<'a, B: ?Sized + DynDynBase, T: ?Sized + DynDynMut<B>> DerefMutHelperDynDyn<'a, B, T> {
-    pub fn __dyn_dyn_check_deref(self) -> Self {
-        self
+    unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(
+        self,
+        metadata: AnyDynMetadata,
+    ) -> <Self::Inner as DowncastUnchecked<'a, B>>::DowncastResult<D> {
+        self.0.downcast_unchecked(metadata)
     }
-}
 
-impl<'a, B: ?Sized + DynDynBase + 'a, T: ?Sized + DynDynMut<B>> DerefHelperEnd
-    for DerefMutHelperDynDyn<'a, B, T>
-{
-    type BaseRef = &'a mut B;
-    type ActualDeref = T;
-
-    fn end(self) -> (&'a mut B, DynDynTable) {
-        DynDynMut::<B>::deref_mut_dyn_dyn(self.0)
+    fn unwrap(self) -> Self::Inner {
+        self.0
     }
-}
-
-#[inline(always)]
-pub unsafe fn try_downcast_mut<B: ?Sized + DynDynBase, D: ?Sized + DynTrait, R: ?Sized>(
-    (ptr, table): (&mut B, DynDynTable),
-    f: impl Fn(*mut D) -> *mut R,
-) -> Option<&mut R> {
-    table
-        .find_dyn(NonNull::from(ptr).cast())
-        .map(|p| &mut *f(p.as_ptr()))
 }

--- a/dyn-dyn/src/lib.rs
+++ b/dyn-dyn/src/lib.rs
@@ -10,6 +10,7 @@
 #![feature(const_type_id)]
 #![cfg_attr(feature = "dynamic-names", feature(const_type_name))]
 #![feature(doc_auto_cfg)]
+#![feature(generic_associated_types)]
 #![feature(ptr_metadata)]
 #![feature(unsize)]
 
@@ -63,12 +64,17 @@ pub use dyn_dyn_macros::dyn_dyn_base;
 ///     dyn_dyn_cast!(Base + Send => Trait + Send, r)
 /// }
 ///
+/// fn downcast_box(r: Box<dyn Base>) -> Option<Box<dyn Trait>> {
+///     dyn_dyn_cast!(move Base => Trait, r)
+/// }
+///
 /// fn main() {
 ///     let mut s = Struct;
 ///
 ///     assert!(downcast(&s).is_some());
 ///     assert!(downcast_mut(&mut s).is_some());
 ///     assert!(downcast_with_auto(&s).is_some());
+///     assert!(downcast_box(Box::new(s)).is_some());
 /// }
 /// ```
 pub use dyn_dyn_macros::dyn_dyn_cast;
@@ -116,11 +122,16 @@ mod fat;
 #[doc(hidden)]
 pub mod internal;
 
+#[cfg(doc)]
+use core::ops::Deref;
+
+use cfg_if::cfg_if;
 use core::any::TypeId;
 use core::fmt::{self, Debug};
-use core::marker::Unsize;
-use core::ops::{Deref, DerefMut};
+use core::marker::{PhantomData, Unsize};
+use core::ops::DerefMut;
 use core::ptr::NonNull;
+use stable_deref_trait::StableDeref;
 
 use crate::dyn_trait::{AnyDynMetadata, DynInfo, DynTrait};
 use internal::*;
@@ -186,16 +197,17 @@ pub struct DynDynTable {
 }
 
 impl DynDynTable {
-    fn find(&self, type_id: TypeId) -> Option<AnyDynMetadata> {
+    /// Finds the metadata corresponding to the type with the provided [`TypeId`] in this table or `None` if no such metadata is present.
+    pub fn find_untyped(&self, type_id: TypeId) -> Option<AnyDynMetadata> {
         self.traits
             .iter()
             .find(|&entry| entry.ty.type_id() == type_id)
             .map(|entry| entry.meta)
     }
 
-    unsafe fn find_dyn<D: DynTrait + ?Sized>(&self, data: NonNull<()>) -> Option<NonNull<D>> {
-        self.find(TypeId::of::<D>())
-            .map(|meta| D::ptr_from_parts(data, meta))
+    /// Finds the metadata corresponding to the trait `D` in this table or `None` if no such metadata is present.
+    pub fn find<D: ?Sized + DynTrait + 'static>(&self) -> Option<AnyDynMetadata> {
+        self.find_untyped(TypeId::of::<D>())
     }
 
     /// Returns a reference to the slice of entries in this table
@@ -229,64 +241,286 @@ impl Iterator for DynDynTableIterator {
     }
 }
 
-/// A pointer that can have its pointee dynamically cast to other trait types via the base trait object type `B`.
+/// Wraps a reference to a pointer implementing [`GetDynDynTable<B>`] and which can be dereferenced to perform the downcast.
 ///
-/// # Safety
-///
-/// Any reference returned by [`DynDyn::deref_dyn_dyn`] must have been received by calling [`Deref::deref`]. The table returned by
-/// [`DynDyn::deref_dyn_dyn`] must correspond to the correct concrete type matching the returned reference. This table must also not change
-/// for any subsequent calls to [`DynDyn::deref_dyn_dyn`] for the lifetime of this pointer.
-pub unsafe trait DynDyn<B: ?Sized + DynDynBase>: Deref {
-    /// Dereferences this pointer, returning a reference to its pointee and a [`DynDynTable`] corresponding to the pointee's concrete type.
-    fn deref_dyn_dyn(&self) -> (&B, DynDynTable);
-}
+/// Using [`dyn_dyn_cast!`] on this struct will call [`GetDynDynTable::get_dyn_dyn_table`] on the pointer itself, then dereference this
+/// pointer to perform the downcast. This allows a pointer implementing [`DynDyn<B>`] to be downcast into a reference without moving the
+/// pointer itself.
+pub struct DynDynRef<'a, B: ?Sized + DynDynBase, T: GetDynDynTable<B> + StableDeref>(
+    &'a T,
+    PhantomData<fn(B) -> B>,
+);
 
-// SAFETY: The DynDynTable returned comes from calling get_dyn_dyn_table on the returned reference. The concrete type of the pointee of a
-//         reference also cannot change for the lifetime of that reference, so the table returned should be stable.
-unsafe impl<'a, B: ?Sized + DynDynBase, T: ?Sized + Unsize<B>> DynDyn<B> for &'a T {
-    #[inline]
-    fn deref_dyn_dyn(&self) -> (&B, DynDynTable) {
-        let tgt = &**self;
-        let table = B::get_dyn_dyn_table(tgt);
-
-        (tgt, table)
+impl<'a, B: ?Sized + DynDynBase, T: GetDynDynTable<B> + StableDeref> DynDynRef<'a, B, T>
+where
+    T::Target: Unsize<B>,
+{
+    /// Creates a new [`DynDynRef`] for the provided reference to a pointer.
+    pub fn new(r: &'a T) -> Self {
+        DynDynRef(r, PhantomData)
     }
 }
 
-// SAFETY: The DynDynTable returned comes from calling get_dyn_dyn_table on the returned reference. The concrete type of the pointee of a
-//         reference also cannot change for the lifetime of that reference, so the table returned should be stable.
-unsafe impl<'a, B: ?Sized + DynDynBase, T: ?Sized + Unsize<B>> DynDyn<B> for &'a mut T {
-    fn deref_dyn_dyn(&self) -> (&B, DynDynTable) {
-        let tgt = &**self;
-        let table = B::get_dyn_dyn_table(tgt);
+/// Wraps a mutable reference to a pointer implementing [`GetDynDynTable<B>`] and which can be dereferenced to perform the downcast.
+///
+/// Using [`dyn_dyn_cast!`] on this struct will call [`GetDynDynTable::get_dyn_dyn_table`] on the pointer itself, then dereference this
+/// pointer to perform the downcast. This allows a pointer implementing [`DynDyn<B>`] to be downcast into a mutable reference without moving
+/// the pointer itself.
+pub struct DynDynRefMut<'a, B: ?Sized + DynDynBase, T: GetDynDynTable<B> + StableDeref + DerefMut>(
+    &'a mut T,
+    PhantomData<fn(B) -> B>,
+);
 
-        (tgt, table)
+impl<'a, B: ?Sized + DynDynBase, T: GetDynDynTable<B> + StableDeref + DerefMut>
+    DynDynRefMut<'a, B, T>
+{
+    /// Creates a new [`DynDynRefMut`] for the provided mutable reference to a pointer.
+    pub fn new(r: &'a mut T) -> Self {
+        DynDynRefMut(r, PhantomData)
     }
 }
 
-/// A pointer that can have its mutable pointee dynamically cast to other trait types via the base trait object type `B`.
+/// A pointer to an object which has a [`DynDynTable`] associated with it.
 ///
 /// # Safety
 ///
-/// Any reference returned by [`DynDynMut::deref_mut_dyn_dyn`] must have been received by calling [`DerefMut::deref_mut`]. The table
-/// returned by [`DynDynMut::deref_mut_dyn_dyn`] must correspond to the correct concrete type matching the returned reference.
-///
-/// Additionally, the [`DynDynTable`] value returned must not change for the lifetime of this pointer and must match the table returned by
-/// calling [`DynDyn::deref_dyn_dyn`].
-pub unsafe trait DynDynMut<B: ?Sized + DynDynBase>: DynDyn<B> + DerefMut {
-    /// Dereferences this pointer, returning a mutable reference to its pointee and a [`DynDynTable`] corresponding to the pointee's
-    /// concrete type.
-    fn deref_mut_dyn_dyn(&mut self) -> (&mut B, DynDynTable);
+/// - If this type implements [`Deref`], then the reference returned by calling [`Deref::deref`] must not change for the lifetime of this
+///   pointer unless the pointer itself is mutated.
+/// - If this type implements [`DerefMut`], then the reference returned by calling [`DerefMut::deref_mut`] must not change for the lifetime
+///   of this pointer unless the pointer itself is mutated and must point to the same object as a reference returned by calling
+///   [`Deref::deref`], including having identical metadata. Additionally, calling [`DerefMut::deref_mut`] must not mutate the pointer.
+/// - If this type implements [`Deref`], then the reference returned by calling [`Deref::deref`] must be unsize-coercible to a reference to
+///   [`GetDynDynTable::get_dyn_dyn_table`].
+/// - If this type implements [`Deref`], then the returned table must be equivalent to calling [`GetDynDynTable::get_dyn_dyn_table`] on a
+///   reference returned by calling [`Deref::deref`].
+/// - If this type implements [`DowncastUnchecked<B>`], then the result of calling [`DowncastUnchecked::downcast_unchecked`] with
+///   metadata retrieved from the table returned by calling [`GetDynDynTable::get_dyn_dyn_table`] on this pointer shall be valid and safe to
+///   use.
+pub unsafe trait GetDynDynTable<B: ?Sized + DynDynBase> {
+    /// The actual type that this pointer currently points to. This type is used to allow propagation of auto trait bounds such as `Send`
+    /// and `Sync` in the `dyn_dyn_cast!` macro.
+    type DynTarget: ?Sized + Unsize<B>;
+
+    /// Gets the [`DynDynTable`] for the object that this pointer points to.
+    fn get_dyn_dyn_table(&self) -> DynDynTable;
 }
 
-// SAFETY: The DynDynTable returned comes from calling get_dyn_dyn_table on the returned reference. The concrete type of the pointee of a
-//         reference also cannot change for the lifetime of that reference, so the table returned should be stable.
-unsafe impl<'a, B: ?Sized + DynDynBase, T: ?Sized + Unsize<B>> DynDynMut<B> for &'a mut T {
-    #[inline]
-    fn deref_mut_dyn_dyn(&mut self) -> (&mut B, DynDynTable) {
-        let tgt = &mut **self;
-        let table = B::get_dyn_dyn_table(tgt);
+/// A pointer to an object that can be unsafely downcast to point to another type.
+pub trait DowncastUnchecked<'a, B: ?Sized + DynDynBase> {
+    /// The result of downcasting this pointer to point to the type `D`. Note that this type need not have the same outer wrapper as the
+    /// type implementing `DowncastUnchecked`, since the result of the downcast may involve coercions and dereferences.
+    type DowncastResult<D: ?Sized + 'a>;
 
-        (tgt, table)
+    /// Downcasts this pointer into a new pointer pointing to the same object, but having type `D`.
+    ///
+    /// Generally, the result of calling this function should be equivalent to turning this pointer type into a raw pointer, removing its
+    /// metadata, unsafely casting that pointer into a pointer to `D` using the provided metadata, and then turning that raw pointer into
+    /// another pointer type.
+    ///
+    /// As long as the concrete type of the pointee matches the concrete type of the metadata provided, then this is guaranteed to result
+    /// in a pointer which is valid and safe to use.
+    ///
+    /// # Safety
+    ///
+    /// Attaching the provided metadata to a pointer to the same data address as that held by this pointer must be guaranteed to be valid
+    /// and safe to use before this function can be called.
+    unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(
+        self,
+        metadata: AnyDynMetadata,
+    ) -> Self::DowncastResult<D>;
+}
+
+/// A pointer object that can be safely downcast to refer to other trait types by using the `dyn_dyn_cast!` macro.
+pub trait DynDyn<'a, B: ?Sized + DynDynBase>: GetDynDynTable<B> + DowncastUnchecked<'a, B> {}
+
+impl<'a, B: ?Sized + DynDynBase, T: GetDynDynTable<B> + DowncastUnchecked<'a, B>> DynDyn<'a, B>
+    for T
+{
+}
+
+// SAFETY: The referent of a shared reference will never change unexpectedly and the table returned matches that returned by dereferencing
+//         it by definition. The DowncastUnchecked implementation is also a simple cast via converting to/from a pointer and so should be
+//         correct.
+unsafe impl<'a, B: ?Sized + DynDynBase, T: ?Sized + Unsize<B>> GetDynDynTable<B> for &'a T {
+    type DynTarget = T;
+
+    fn get_dyn_dyn_table(&self) -> DynDynTable {
+        B::get_dyn_dyn_table(*self)
+    }
+}
+
+impl<'a, B: ?Sized + DynDynBase, T: ?Sized + Unsize<B>> DowncastUnchecked<'a, B> for &'a T {
+    type DowncastResult<D: ?Sized + 'a> = &'a D;
+
+    unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(self, metadata: AnyDynMetadata) -> &'a D {
+        &*D::ptr_from_parts(NonNull::from(self).cast(), metadata).as_ptr()
+    }
+}
+
+// SAFETY: Since T is StableDeref, the results of its Deref implementation should meet the stability requirements and the table returned is
+//         simply passed through from T's GetDynDynTable<B> implementation, which is unsafe itself and can be assumed to be correct. The
+//         DowncastUnchecked implementation defers to the impl for &T::Target, so it should be correct.
+unsafe impl<'a, B: ?Sized + DynDynBase, T: GetDynDynTable<B> + StableDeref + 'a> GetDynDynTable<B>
+    for DynDynRef<'a, B, T>
+where
+    T::Target: Unsize<B>,
+{
+    type DynTarget = T::DynTarget;
+
+    fn get_dyn_dyn_table(&self) -> DynDynTable {
+        <T as GetDynDynTable<B>>::get_dyn_dyn_table(self.0)
+    }
+}
+
+impl<'a, B: ?Sized + DynDynBase, T: DynDyn<'a, B> + StableDeref + 'a> DowncastUnchecked<'a, B>
+    for DynDynRef<'a, B, T>
+where
+    T::Target: Unsize<B>,
+{
+    type DowncastResult<D: ?Sized + 'a> = &'a D;
+
+    unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(
+        self,
+        metadata: AnyDynMetadata,
+    ) -> Self::DowncastResult<D> {
+        <&T::Target as DowncastUnchecked<B>>::downcast_unchecked(&**self.0, metadata)
+    }
+}
+
+// SAFETY: The referent of a mutable reference will never change unexpectedly and the table is returned by deferring to &T's implementation
+//         and so should be correct. The DowncastUnchecked implementation is also a simple cast via converting to/from a pointer and so
+//         should also be correct.
+unsafe impl<'a, B: ?Sized + DynDynBase, T: ?Sized + Unsize<B>> GetDynDynTable<B> for &'a mut T {
+    type DynTarget = T;
+
+    fn get_dyn_dyn_table(&self) -> DynDynTable {
+        B::get_dyn_dyn_table(*self)
+    }
+}
+
+impl<'a, B: ?Sized + DynDynBase, T: ?Sized + Unsize<B>> DowncastUnchecked<'a, B> for &'a mut T {
+    type DowncastResult<D: ?Sized + 'a> = &'a mut D;
+
+    unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(
+        self,
+        metadata: AnyDynMetadata,
+    ) -> &'a mut D {
+        &mut *D::ptr_from_parts(NonNull::from(self).cast(), metadata).as_ptr()
+    }
+}
+
+// SAFETY: Since T is StableDeref, the results of its Deref and DerefMut implementations should meet the stability requirements and the
+//         table returned is simply passed through from T's GetDynDynTable<B> implementation, which is unsafe itself and can be assumed to
+//         be correct. The DowncastUnchecked implementation defers to the impl for &mut T::Target, so it should be correct.
+unsafe impl<'a, B: ?Sized + DynDynBase, T: DynDyn<'a, B> + StableDeref + DerefMut + 'a>
+    GetDynDynTable<B> for DynDynRefMut<'a, B, T>
+where
+    T::Target: Unsize<B>,
+{
+    type DynTarget = T::Target;
+
+    fn get_dyn_dyn_table(&self) -> DynDynTable {
+        <T as GetDynDynTable<B>>::get_dyn_dyn_table(self.0)
+    }
+}
+
+impl<'a, B: ?Sized + DynDynBase, T: DynDyn<'a, B> + StableDeref + DerefMut + 'a>
+    DowncastUnchecked<'a, B> for DynDynRefMut<'a, B, T>
+where
+    T::Target: Unsize<B>,
+{
+    type DowncastResult<D: ?Sized + 'a> = &'a mut D;
+
+    unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(
+        self,
+        metadata: AnyDynMetadata,
+    ) -> Self::DowncastResult<D> {
+        <&mut T::Target as DowncastUnchecked<B>>::downcast_unchecked(&mut **self.0, metadata)
+    }
+}
+
+cfg_if! {
+    if #[cfg(feature = "alloc")] {
+        use alloc::boxed::Box;
+        use alloc::sync::Arc;
+        use alloc::rc::Rc;
+
+        // SAFETY: Box<T> meets all Deref/DerefMut stability requirements and the table is retrieved by dereferencing it, which is correct
+        //         by definition. The DowncastUnchecked implementation is also a simple cast via converting to/from a pointer and so should
+        //         be correct.
+        unsafe impl<B: ?Sized + DynDynBase, T: ?Sized + Unsize<B>> GetDynDynTable<B> for Box<T> {
+            type DynTarget = T;
+
+            fn get_dyn_dyn_table(&self) -> DynDynTable {
+                B::get_dyn_dyn_table(&**self)
+            }
+        }
+
+        impl<'a, B: ?Sized + DynDynBase, T: ?Sized + Unsize<B> + 'a> DowncastUnchecked<'a, B>
+            for Box<T>
+        {
+            type DowncastResult<D: ?Sized + 'a> = Box<D>;
+
+            unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(self, metadata: AnyDynMetadata) -> Box<D> {
+                Box::from_raw(
+                    D::ptr_from_parts(NonNull::new_unchecked(Box::into_raw(self)).cast(), metadata)
+                        .as_ptr(),
+                )
+            }
+        }
+
+        // SAFETY: Rc<T> meets all Deref/DerefMut stability requirements and the table is retrieved by dereferencing it, which is correct by
+        //         definition. The DowncastUnchecked implementation is also a simple cast via converting to/from a pointer and so should be
+        //         correct.
+        unsafe impl<B: ?Sized + DynDynBase, T: ?Sized + Unsize<B>> GetDynDynTable<B> for Rc<T> {
+            type DynTarget = T;
+
+            fn get_dyn_dyn_table(&self) -> DynDynTable {
+                B::get_dyn_dyn_table(&**self)
+            }
+        }
+
+        impl<'a, B: ?Sized + DynDynBase, T: ?Sized + Unsize<B> + 'a> DowncastUnchecked<'a, B>
+            for Rc<T>
+        {
+            type DowncastResult<D: ?Sized + 'a> = Rc<D>;
+
+            unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(self, metadata: AnyDynMetadata) -> Rc<D> {
+                Rc::from_raw(
+                    D::ptr_from_parts(
+                        NonNull::new_unchecked(Rc::into_raw(self) as *mut T).cast(),
+                        metadata,
+                    )
+                    .as_ptr(),
+                )
+            }
+        }
+
+        // SAFETY: Arc<T> meets all Deref/DerefMut stability requirements and the table is retrieved by dereferencing it, which is correct
+        //         by definition. The DowncastUnchecked implementation is also a simple cast via converting to/from a pointer and so should
+        //         be correct.
+        unsafe impl<B: ?Sized + DynDynBase, T: ?Sized + Unsize<B>> GetDynDynTable<B> for Arc<T> {
+            type DynTarget = T;
+
+            fn get_dyn_dyn_table(&self) -> DynDynTable {
+                B::get_dyn_dyn_table(&**self)
+            }
+        }
+
+        impl<'a, B: ?Sized + DynDynBase, T: ?Sized + Unsize<B> + 'a> DowncastUnchecked<'a, B>
+            for Arc<T>
+        {
+            type DowncastResult<D: ?Sized + 'a> = Arc<D>;
+
+            unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(self, metadata: AnyDynMetadata) -> Arc<D> {
+                Arc::from_raw(
+                    D::ptr_from_parts(
+                        NonNull::new_unchecked(Arc::into_raw(self) as *mut T).cast(),
+                        metadata,
+                    )
+                    .as_ptr(),
+                )
+            }
+        }
     }
 }

--- a/dyn-dyn/tests/fat.rs
+++ b/dyn-dyn/tests/fat.rs
@@ -7,7 +7,7 @@ use alloc::rc::Rc;
 use core::cell::Cell;
 use core::ops::Deref;
 use dyn_dyn::internal::DynDynBase;
-use dyn_dyn::{dyn_dyn_cast, DynDynFat, DynDynTable, DynDynTableEntry};
+use dyn_dyn::{dyn_dyn_cast, DynDynFat, DynDynTable, DynDynTableEntry, GetDynDynTable};
 use stable_deref_trait::StableDeref;
 
 // We need the pointers to these two tables to be distinct in order to properly differentiate them, so these cannot be declared as
@@ -54,6 +54,14 @@ impl<'a> Deref for WeirdCloneBox<'a> {
 
 // SAFETY: Just a wrapper around Box<TestStruct<'a>>
 unsafe impl<'a> StableDeref for WeirdCloneBox<'a> {}
+
+unsafe impl<'a> GetDynDynTable<dyn Base + 'a> for WeirdCloneBox<'a> {
+    type DynTarget = dyn Base;
+
+    fn get_dyn_dyn_table(&self) -> DynDynTable {
+        <&TestStruct as GetDynDynTable<dyn Base + 'a>>::get_dyn_dyn_table(&&*self.0)
+    }
+}
 
 #[test]
 fn test_get_table_cached() {


### PR DESCRIPTION
Previously, the way the DynDyn trait worked only ever allowed
downcasting into &D or &mut D types. However, when downcasted types need
to be stored in a data structure, it might be beneficial to e.g.
downcast a Box<dyn Base> into a Box<dyn Trait>.

In order to accomodate this use case, the DynDyn trait has been
completely reworked, along with reworking how the dyn_dyn_cast! macro is
implemented. Now, when a dyn_dyn_cast! invocation starts with the
keyword `move`, it is possible to perform downcasts on smart pointers in
this manner.