### PR TITLE
Change dyn_dyn_cast! to return a Result

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ impl BaseTrait for Struct {}
 fn main() {
     let mut s = Struct;
 
-    assert!(dyn_dyn_cast!(BaseTrait => ExposedTrait, &s).is_some());
-    assert!(dyn_dyn_cast!(mut BaseTrait => ExposedTrait, &mut s).is_some());
-    assert!(dyn_dyn_cast!(move BaseTrait => ExposedTrait, Box::new(s)).is_some());
+    assert!(dyn_dyn_cast!(BaseTrait => ExposedTrait, &s).is_ok());
+    assert!(dyn_dyn_cast!(mut BaseTrait => ExposedTrait, &mut s).is_ok());
+    assert!(dyn_dyn_cast!(move BaseTrait => ExposedTrait, Box::new(s)).is_ok());
 }
 ```
 

--- a/dyn-dyn-macros/src/cast.rs
+++ b/dyn-dyn-macros/src/cast.rs
@@ -131,12 +131,16 @@ pub fn dyn_dyn_cast(input: DynDynCastInput) -> TokenStream {
 
                 let __dyn_dyn_table = ::dyn_dyn::internal::DerefHelperEnd::<dyn #base_primary_trait>::get_dyn_dyn_table(&__dyn_dyn_input);
                 if true {
-                    __dyn_dyn_table.find::<dyn #tgt_primary_trait>().map(|__dyn_dyn_metadata| {
+                    if let ::core::option::Option::Some(__dyn_dyn_metadata) = __dyn_dyn_table.find::<dyn #tgt_primary_trait>() {
                         #cast_metadata
-                        ::dyn_dyn::internal::DerefHelperEnd::<dyn #base_primary_trait>::downcast_unchecked::<
+                        ::core::result::Result::Ok(::dyn_dyn::internal::DerefHelperEnd::<dyn #base_primary_trait>::downcast_unchecked::<
                             dyn #tgt_primary_trait #(+ #tgt_markers)*
-                        >(__dyn_dyn_input, __dyn_dyn_metadata)
-                    })
+                        >(__dyn_dyn_input, __dyn_dyn_metadata))
+                    } else {
+                        ::core::result::Result::Err(::dyn_dyn::internal::DerefHelperEnd::<dyn #base_primary_trait>::into_err(
+                            __dyn_dyn_input
+                        ))
+                    }
                 } else {
                     fn __dyn_dyn_constrain_lifetime<
                         '__dyn_dyn_ref,
@@ -150,7 +154,7 @@ pub fn dyn_dyn_cast(input: DynDynCastInput) -> TokenStream {
                         unreachable!()
                     }
 
-                    Some(__dyn_dyn_constrain_lifetime(
+                    ::core::result::Result::Ok(__dyn_dyn_constrain_lifetime(
                         ::dyn_dyn::internal::DerefHelperEnd::<dyn #base_primary_trait>::unwrap(__dyn_dyn_input)
                     ))
                 }

--- a/dyn-dyn/src/internal.rs
+++ b/dyn-dyn/src/internal.rs
@@ -43,6 +43,7 @@ pub trait DerefHelperT: Sized {
 
 pub trait DerefHelperEnd<'a, B: ?Sized + DynDynBase> {
     type Inner: DynDyn<'a, B>;
+    type Err;
 
     fn get_dyn_dyn_table(&self) -> DynDynTable;
     unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(
@@ -50,6 +51,7 @@ pub trait DerefHelperEnd<'a, B: ?Sized + DynDynBase> {
         metadata: DynMetadata<D>,
     ) -> <Self::Inner as DowncastUnchecked<'a, B>>::DowncastResult<D>;
     fn unwrap(self) -> Self::Inner;
+    fn into_err(self) -> Self::Err;
     fn typecheck(&self) -> &<Self::Inner as GetDynDynTable<B>>::DynTarget {
         panic!("this method is only meant to be used for typechecking");
     }
@@ -78,8 +80,8 @@ impl<'a, B: ?Sized + DynDynBase, T: ?Sized> DerefHelper<B, &'a mut T> {
 }
 
 impl<'a, B: ?Sized + DynDynBase, T: DynDyn<'a, B>> DerefHelper<B, T> {
-    pub fn __dyn_dyn_check_dyn_dyn(self) -> DerefHelperResolved<'a, B, T> {
-        DerefHelperResolved(self.0, self.1, PhantomData)
+    pub fn __dyn_dyn_check_dyn_dyn(self) -> DerefHelperResolved<'a, B, T, T, impl FnOnce(T) -> T> {
+        DerefHelperResolved(self.0, |x| x, self.1, PhantomData)
     }
 }
 
@@ -90,8 +92,19 @@ where
 {
     pub fn __dyn_dyn_check_ref_mut_dyn_dyn(
         self,
-    ) -> DerefHelperResolved<'a, B, DynDynRefMut<'a, B, T>> {
-        DerefHelperResolved(DynDynRefMut::new(self.0), self.1, PhantomData)
+    ) -> DerefHelperResolved<
+        'a,
+        B,
+        DynDynRefMut<'a, B, T>,
+        &'a mut T::Target,
+        impl FnOnce(DynDynRefMut<'a, B, T>) -> &'a mut T::Target,
+    > {
+        DerefHelperResolved(
+            DynDynRefMut::new(self.0),
+            |x| &mut **x.0,
+            self.1,
+            PhantomData,
+        )
     }
 }
 
@@ -99,8 +112,16 @@ impl<'a, B: ?Sized + DynDynBase, T: DynDyn<'a, B> + StableDeref> DerefHelper<B, 
 where
     T::Target: Unsize<B>,
 {
-    pub fn __dyn_dyn_check_ref_dyn_dyn(self) -> DerefHelperResolved<'a, B, DynDynRef<'a, B, T>> {
-        DerefHelperResolved(DynDynRef::new(self.0), self.1, PhantomData)
+    pub fn __dyn_dyn_check_ref_dyn_dyn(
+        self,
+    ) -> DerefHelperResolved<
+        'a,
+        B,
+        DynDynRef<'a, B, T>,
+        &'a T::Target,
+        impl FnOnce(DynDynRef<'a, B, T>) -> &'a T::Target,
+    > {
+        DerefHelperResolved(DynDynRef::new(self.0), |x| &**x.0, self.1, PhantomData)
     }
 }
 
@@ -108,8 +129,16 @@ impl<'a, B: ?Sized + DynDynBase, T: DerefMut> DerefHelper<B, &'a mut T>
 where
     T::Target: Unsize<B>,
 {
-    pub fn __dyn_dyn_check_deref_mut(self) -> DerefHelperResolved<'a, B, &'a mut T::Target> {
-        DerefHelperResolved(&mut **self.0, self.1, PhantomData)
+    pub fn __dyn_dyn_check_deref_mut(
+        self,
+    ) -> DerefHelperResolved<
+        'a,
+        B,
+        &'a mut T::Target,
+        &'a mut T::Target,
+        impl FnOnce(&'a mut T::Target) -> &'a mut T::Target,
+    > {
+        DerefHelperResolved(&mut **self.0, |x| x, self.1, PhantomData)
     }
 }
 
@@ -117,23 +146,36 @@ impl<'a, B: ?Sized + DynDynBase, T: Deref> DerefHelper<B, &'a T>
 where
     T::Target: Unsize<B>,
 {
-    pub fn __dyn_dyn_check_deref(self) -> DerefHelperResolved<'a, B, &'a T::Target> {
-        DerefHelperResolved(&**self.0, self.1, PhantomData)
+    pub fn __dyn_dyn_check_deref(
+        self,
+    ) -> DerefHelperResolved<
+        'a,
+        B,
+        &'a T::Target,
+        &'a T::Target,
+        impl FnOnce(&'a T::Target) -> &'a T::Target,
+    > {
+        DerefHelperResolved(&**self.0, |x| x, self.1, PhantomData)
     }
 }
 
-pub struct DerefHelperResolved<'a, B: ?Sized + DynDynBase, T: DynDyn<'a, B>>(
+pub struct DerefHelperResolved<'a, B: ?Sized + DynDynBase, T: DynDyn<'a, B>, E, F: FnOnce(T) -> E>(
     T,
+    F,
     PhantomData<fn(B) -> B>,
     PhantomData<&'a ()>,
 );
 
-impl<'a, B: ?Sized + DynDynBase, T: DynDyn<'a, B>> DerefHelperT for DerefHelperResolved<'a, B, T> {}
+impl<'a, B: ?Sized + DynDynBase, T: DynDyn<'a, B>, E, F: FnOnce(T) -> E> DerefHelperT
+    for DerefHelperResolved<'a, B, T, E, F>
+{
+}
 
-impl<'a, B: ?Sized + DynDynBase, T: DynDyn<'a, B>> DerefHelperEnd<'a, B>
-    for DerefHelperResolved<'a, B, T>
+impl<'a, B: ?Sized + DynDynBase, T: DynDyn<'a, B>, E, F: FnOnce(T) -> E> DerefHelperEnd<'a, B>
+    for DerefHelperResolved<'a, B, T, E, F>
 {
     type Inner = T;
+    type Err = E;
 
     fn get_dyn_dyn_table(&self) -> DynDynTable {
         self.0.get_dyn_dyn_table()
@@ -148,6 +190,10 @@ impl<'a, B: ?Sized + DynDynBase, T: DynDyn<'a, B>> DerefHelperEnd<'a, B>
 
     fn unwrap(self) -> Self::Inner {
         self.0
+    }
+
+    fn into_err(self) -> Self::Err {
+        self.1(self.0)
     }
 }
 

--- a/dyn-dyn/src/lib.rs
+++ b/dyn-dyn/src/lib.rs
@@ -52,29 +52,29 @@ pub use dyn_dyn_macros::dyn_dyn_base;
 /// impl Base for Struct {}
 /// impl Trait for Struct {}
 ///
-/// fn downcast(r: &dyn Base) -> Option<&dyn Trait> {
+/// fn downcast(r: &dyn Base) -> Result<&dyn Trait, &dyn Base> {
 ///     dyn_dyn_cast!(Base => Trait, r)
 /// }
 ///
-/// fn downcast_mut(r: &mut dyn Base) -> Option<&mut dyn Trait> {
+/// fn downcast_mut(r: &mut dyn Base) -> Result<&mut dyn Trait, &mut dyn Base> {
 ///     dyn_dyn_cast!(mut Base => Trait, r)
 /// }
 ///
-/// fn downcast_with_auto(r: &(dyn Base + Send)) -> Option<&(dyn Trait + Send)> {
+/// fn downcast_with_auto(r: &(dyn Base + Send)) -> Result<&(dyn Trait + Send), &(dyn Base + Send)> {
 ///     dyn_dyn_cast!(Base + Send => Trait + Send, r)
 /// }
 ///
-/// fn downcast_box(r: Box<dyn Base>) -> Option<Box<dyn Trait>> {
+/// fn downcast_box(r: Box<dyn Base>) -> Result<Box<dyn Trait>, Box<dyn Base>> {
 ///     dyn_dyn_cast!(move Base => Trait, r)
 /// }
 ///
 /// fn main() {
 ///     let mut s = Struct;
 ///
-///     assert!(downcast(&s).is_some());
-///     assert!(downcast_mut(&mut s).is_some());
-///     assert!(downcast_with_auto(&s).is_some());
-///     assert!(downcast_box(Box::new(s)).is_some());
+///     assert!(downcast(&s).is_ok());
+///     assert!(downcast_mut(&mut s).is_ok());
+///     assert!(downcast_with_auto(&s).is_ok());
+///     assert!(downcast_box(Box::new(s)).is_ok());
 /// }
 /// ```
 pub use dyn_dyn_macros::dyn_dyn_cast;

--- a/dyn-dyn/tests/fat.rs
+++ b/dyn-dyn/tests/fat.rs
@@ -74,8 +74,8 @@ fn test_get_table_cached() {
         &EMPTY_TABLE_1.1[..] as *const _,
         DynDynFat::get_dyn_dyn_table(&ptr).into_slice() as *const _
     );
-    dyn_dyn_cast!(Base => Base, &ptr);
-    dyn_dyn_cast!(mut Base => Base, &mut ptr);
+    let _ = dyn_dyn_cast!(Base => Base, &ptr);
+    let _ = dyn_dyn_cast!(mut Base => Base, &mut ptr);
     assert_eq!(1, num_table_calls.get());
 }
 

--- a/dyn-dyn/tests/generics.rs
+++ b/dyn-dyn/tests/generics.rs
@@ -19,11 +19,11 @@ fn test_generic_base() {
     impl TestTraitA for TestStruct {}
     impl TestTraitB for TestStruct {}
 
-    assert!(dyn_dyn_cast!(Base<u32> => TestTraitA, &TestStruct as &dyn Base<u32>).is_some());
-    assert!(dyn_dyn_cast!(Base<u32> => TestTraitB, &TestStruct as &dyn Base<u32>).is_none());
+    assert!(dyn_dyn_cast!(Base<u32> => TestTraitA, &TestStruct as &dyn Base<u32>).is_ok());
+    assert!(dyn_dyn_cast!(Base<u32> => TestTraitB, &TestStruct as &dyn Base<u32>).is_err());
 
-    assert!(dyn_dyn_cast!(Base<u64> => TestTraitA, &TestStruct as &dyn Base<u64>).is_none());
-    assert!(dyn_dyn_cast!(Base<u64> => TestTraitB, &TestStruct as &dyn Base<u64>).is_some());
+    assert!(dyn_dyn_cast!(Base<u64> => TestTraitA, &TestStruct as &dyn Base<u64>).is_err());
+    assert!(dyn_dyn_cast!(Base<u64> => TestTraitB, &TestStruct as &dyn Base<u64>).is_ok());
 }
 
 #[test]
@@ -51,16 +51,22 @@ fn test_generic_trait() {
     }
 
     assert_eq!(
-        Some(0),
-        dyn_dyn_cast!(Base => GenericTrait<u32>, &TestStruct as &dyn Base).map(|b| b.test())
+        Ok(0),
+        dyn_dyn_cast!(Base => GenericTrait<u32>, &TestStruct as &dyn Base)
+            .map(|b| b.test())
+            .map_err(|_| ())
     );
     assert_eq!(
-        Some(1),
-        dyn_dyn_cast!(Base => GenericTrait<u64>, &TestStruct as &dyn Base).map(|b| b.test())
+        Ok(1),
+        dyn_dyn_cast!(Base => GenericTrait<u64>, &TestStruct as &dyn Base)
+            .map(|b| b.test())
+            .map_err(|_| ())
     );
     assert_eq!(
-        None,
-        dyn_dyn_cast!(Base => GenericTrait<u16>, &TestStruct as &dyn Base).map(|b| b.test())
+        Err(()),
+        dyn_dyn_cast!(Base => GenericTrait<u16>, &TestStruct as &dyn Base)
+            .map(|b| b.test())
+            .map_err(|_| ())
     );
 }
 
@@ -85,21 +91,29 @@ fn test_generic_trait_from_param() {
     }
 
     assert_eq!(
-        Some(1234),
-        dyn_dyn_cast!(Base => GenericTrait<u32>, &TestStruct(0_u32) as &dyn Base).map(|b| b.test())
+        Ok(1234),
+        dyn_dyn_cast!(Base => GenericTrait<u32>, &TestStruct(0_u32) as &dyn Base)
+            .map(|b| b.test())
+            .map_err(|_| ())
     );
     assert_eq!(
-        None,
-        dyn_dyn_cast!(Base => GenericTrait<u64>, &TestStruct(0_u32) as &dyn Base).map(|b| b.test())
+        Err(()),
+        dyn_dyn_cast!(Base => GenericTrait<u64>, &TestStruct(0_u32) as &dyn Base)
+            .map(|b| b.test())
+            .map_err(|_| ())
     );
 
     assert_eq!(
-        None,
-        dyn_dyn_cast!(Base => GenericTrait<u32>, &TestStruct(0_u64) as &dyn Base).map(|b| b.test())
+        Err(()),
+        dyn_dyn_cast!(Base => GenericTrait<u32>, &TestStruct(0_u64) as &dyn Base)
+            .map(|b| b.test())
+            .map_err(|_| ())
     );
     assert_eq!(
-        Some(1234),
-        dyn_dyn_cast!(Base => GenericTrait<u64>, &TestStruct(0_u64) as &dyn Base).map(|b| b.test())
+        Ok(1234),
+        dyn_dyn_cast!(Base => GenericTrait<u64>, &TestStruct(0_u64) as &dyn Base)
+            .map(|b| b.test())
+            .map_err(|_| ())
     );
 }
 
@@ -116,16 +130,16 @@ fn test_generic_base_from_param() {
     impl<T: 'static> TestTrait<T> for TestStruct<T> {}
 
     assert!(
-        dyn_dyn_cast!(Base<u32> => TestTrait<u32>, &TestStruct(0_u32) as &dyn Base<u32>).is_some()
+        dyn_dyn_cast!(Base<u32> => TestTrait<u32>, &TestStruct(0_u32) as &dyn Base<u32>).is_ok()
     );
     assert!(
-        dyn_dyn_cast!(Base<u32> => TestTrait<u64>, &TestStruct(0_u32) as &dyn Base<u32>).is_none()
+        dyn_dyn_cast!(Base<u32> => TestTrait<u64>, &TestStruct(0_u32) as &dyn Base<u32>).is_err()
     );
     assert!(
-        dyn_dyn_cast!(Base<u64> => TestTrait<u32>, &TestStruct(0_u64) as &dyn Base<u64>).is_none()
+        dyn_dyn_cast!(Base<u64> => TestTrait<u32>, &TestStruct(0_u64) as &dyn Base<u64>).is_err()
     );
     assert!(
-        dyn_dyn_cast!(Base<u64> => TestTrait<u64>, &TestStruct(0_u64) as &dyn Base<u64>).is_some()
+        dyn_dyn_cast!(Base<u64> => TestTrait<u64>, &TestStruct(0_u64) as &dyn Base<u64>).is_ok()
     );
 }
 
@@ -141,10 +155,10 @@ fn test_generic_base_blanket_impl() {
     impl<T: 'static> Base<T> for TestStruct {}
     impl<T: 'static> TestTrait<T> for TestStruct {}
 
-    assert!(dyn_dyn_cast!(Base<u32> => TestTrait<u32>, &TestStruct as &dyn Base<u32>).is_some());
-    assert!(dyn_dyn_cast!(Base<u32> => TestTrait<u64>, &TestStruct as &dyn Base<u32>).is_none());
-    assert!(dyn_dyn_cast!(Base<u64> => TestTrait<u32>, &TestStruct as &dyn Base<u64>).is_none());
-    assert!(dyn_dyn_cast!(Base<u64> => TestTrait<u64>, &TestStruct as &dyn Base<u64>).is_some());
+    assert!(dyn_dyn_cast!(Base<u32> => TestTrait<u32>, &TestStruct as &dyn Base<u32>).is_ok());
+    assert!(dyn_dyn_cast!(Base<u32> => TestTrait<u64>, &TestStruct as &dyn Base<u32>).is_err());
+    assert!(dyn_dyn_cast!(Base<u64> => TestTrait<u32>, &TestStruct as &dyn Base<u64>).is_err());
+    assert!(dyn_dyn_cast!(Base<u64> => TestTrait<u64>, &TestStruct as &dyn Base<u64>).is_ok());
 }
 
 #[test]
@@ -163,7 +177,7 @@ fn test_where_clause_on_base() {
     impl Base<u32> for TestStruct {}
     impl TestTrait for TestStruct {}
 
-    assert!(dyn_dyn_cast!(Base<u32> => TestTrait, &TestStruct as &dyn Base<u32>).is_some());
+    assert!(dyn_dyn_cast!(Base<u32> => TestTrait, &TestStruct as &dyn Base<u32>).is_ok());
 }
 
 #[test]
@@ -189,20 +203,28 @@ fn test_where_clause_on_derived() {
     }
 
     assert_eq!(
-        Some(1234),
-        dyn_dyn_cast!(Base => GenericTrait<u32>, &TestStruct(0_u32) as &dyn Base).map(|b| b.test())
+        Ok(1234),
+        dyn_dyn_cast!(Base => GenericTrait<u32>, &TestStruct(0_u32) as &dyn Base)
+            .map(|b| b.test())
+            .map_err(|_| ())
     );
     assert_eq!(
-        None,
-        dyn_dyn_cast!(Base => GenericTrait<u64>, &TestStruct(0_u32) as &dyn Base).map(|b| b.test())
+        Err(()),
+        dyn_dyn_cast!(Base => GenericTrait<u64>, &TestStruct(0_u32) as &dyn Base)
+            .map(|b| b.test())
+            .map_err(|_| ())
     );
 
     assert_eq!(
-        None,
-        dyn_dyn_cast!(Base => GenericTrait<u32>, &TestStruct(0_u64) as &dyn Base).map(|b| b.test())
+        Err(()),
+        dyn_dyn_cast!(Base => GenericTrait<u32>, &TestStruct(0_u64) as &dyn Base)
+            .map(|b| b.test())
+            .map_err(|_| ())
     );
     assert_eq!(
-        Some(1234),
-        dyn_dyn_cast!(Base => GenericTrait<u64>, &TestStruct(0_u64) as &dyn Base).map(|b| b.test())
+        Ok(1234),
+        dyn_dyn_cast!(Base => GenericTrait<u64>, &TestStruct(0_u64) as &dyn Base)
+            .map(|b| b.test())
+            .map_err(|_| ())
     );
 }

--- a/dyn-dyn/tests/send_sync.rs
+++ b/dyn-dyn/tests/send_sync.rs
@@ -19,58 +19,63 @@ impl TestTrait for TestStruct {
 #[test]
 fn test_plain_dyn_from_send_sync() {
     assert_eq!(
-        Some(0xdeadbeef),
+        Ok(0xdeadbeef),
         dyn_dyn_cast!(BaseTrait + Send => TestTrait, &TestStruct as &(dyn BaseTrait + Send))
             .map(|t| t.test())
+            .map_err(|_| ())
     );
     assert_eq!(
-        Some(0xdeadbeef),
+        Ok(0xdeadbeef),
         dyn_dyn_cast!(BaseTrait + Sync => TestTrait, &TestStruct as &(dyn BaseTrait + Sync))
             .map(|t| t.test())
+            .map_err(|_| ())
     );
     assert_eq!(
-        Some(0xdeadbeef),
+        Ok(0xdeadbeef),
         dyn_dyn_cast!(BaseTrait + Send + Sync => TestTrait, &TestStruct as &(dyn BaseTrait + Send + Sync))
-            .map(|t| t.test())
+            .map(|t| t.test()).map_err(|_| ())
     );
 }
 
 #[test]
 fn test_send_dyn() {
     assert_eq!(
-        Some(0xdeadbeef),
+        Ok(0xdeadbeef),
         dyn_dyn_cast!(BaseTrait + Send => TestTrait + Send, &TestStruct as &(dyn BaseTrait + Send))
             .map(|t| t.test())
+            .map_err(|_| ())
     );
     assert_eq!(
-        Some(0xdeadbeef),
+        Ok(0xdeadbeef),
         dyn_dyn_cast!(BaseTrait + Send + Sync => TestTrait + Send, &TestStruct as &(dyn BaseTrait + Send + Sync))
-            .map(|t| t.test())
+            .map(|t| t.test()).map_err(|_| ())
     );
 }
 
 #[test]
 fn test_sync_dyn() {
     assert_eq!(
-        Some(0xdeadbeef),
+        Ok(0xdeadbeef),
         dyn_dyn_cast!(BaseTrait + Sync => TestTrait + Sync, &TestStruct as &(dyn BaseTrait + Sync))
             .map(|t| t.test())
+            .map_err(|_| ())
     );
     assert_eq!(
-        Some(0xdeadbeef),
+        Ok(0xdeadbeef),
         dyn_dyn_cast!(BaseTrait + Send + Sync => TestTrait + Sync, &TestStruct as &(dyn BaseTrait + Send + Sync))
-            .map(|t| t.test())
+            .map(|t| t.test()).map_err(|_| ())
     );
 }
 
 #[test]
 fn test_send_sync_dyn() {
     assert_eq!(
-        Some(0xdeadbeef),
+        Ok(0xdeadbeef),
         dyn_dyn_cast!(
             BaseTrait + Send + Sync => TestTrait + Send + Sync,
             &TestStruct as &(dyn BaseTrait + Send + Sync)
         )
         .map(|t| t.test())
+        .map_err(|_| ())
     );
 }


### PR DESCRIPTION
Previously, the dyn_dyn_cast! method would return an Option that
contains the downcasted value if the downcast was valid and None
otherwise. However, this was suboptimal since there was no way to get
the originally passed in value if the downcast failed. This wasn't a big
deal back when only references could be used, but now that smart
pointers can be downcast, this has become an issue since the smart
pointer will be unconditionally dropped if the downcast isn't valid.

In order to combat this, dyn_dyn_cast! has been changed to return a
Result instead of an Option. This means that the original value can be
returned in an Err if the downcast fails.