### PR TITLE
Switch DynDynTableEntry::new to use Unsize

### DIFF
--- a/dyn-dyn-macros/src/derived.rs
+++ b/dyn-dyn-macros/src/derived.rs
@@ -56,10 +56,7 @@ pub fn dyn_dyn_derived(args: Punctuated<Type, Token![,]>, input: ItemImpl) -> To
         Some(quote!(::))
     };
 
-    let convert_fns_0 = (0..num_table_entries).map(|i| format_ident!("__convert_{}", i));
-    let convert_tys_0 = args.iter();
-    let convert_fns_1 = convert_fns_0.clone();
-    let convert_tys_1 = args.iter();
+    let convert_tys = args.iter();
 
     let marker_contents = input.generics.params.iter().filter_map(|p| match *p {
         GenericParam::Type(ref p) => Some(p.ident.clone()),
@@ -75,21 +72,11 @@ pub fn dyn_dyn_derived(args: Punctuated<Type, Token![,]>, input: ItemImpl) -> To
         struct #table_ident #generics(#marker_contents) #where_clause;
 
         impl #impl_generics #table_ident #type_generics #where_clause {
-            #(
-                const fn #convert_fns_0(p: *const #self_ty) -> *const dyn #convert_tys_0 {
-                    p as *const dyn #convert_tys_0
-                }
-            )*
-
-            pub const __TABLE: [::dyn_dyn::DynDynTableEntry; #num_table_entries] = unsafe { [
+            pub const __TABLE: [::dyn_dyn::DynDynTableEntry; #num_table_entries] = [
                 #(
-                    ::dyn_dyn::DynDynTableEntry::new::<
-                        #self_ty,
-                        dyn #convert_tys_1,
-                        _
-                    >(Self::#convert_fns_1)
+                    ::dyn_dyn::DynDynTableEntry::new::<#self_ty, dyn #convert_tys>()
                 ),*
-            ] };
+            ];
         }
 
         unsafe impl #impl_generics ::dyn_dyn::internal::DynDynDerived<dyn #trait_> for #self_ty #where_clause {

--- a/dyn-dyn/src/table.rs
+++ b/dyn-dyn/src/table.rs
@@ -2,6 +2,7 @@ use crate::dyn_trait::{AnyDynMetadata, DynTrait};
 use cfg_if::cfg_if;
 use core::any::TypeId;
 use core::fmt::{self, Debug};
+use core::marker::Unsize;
 use core::ptr::DynMetadata;
 
 #[cfg(doc)]
@@ -60,16 +61,10 @@ pub struct DynDynTableEntry {
 
 impl DynDynTableEntry {
     #[doc(hidden)]
-    pub const unsafe fn new<
-        T,
-        D: ?Sized + ~const DynTrait + 'static,
-        F: ~const FnOnce(*const T) -> *const D,
-    >(
-        f: F,
-    ) -> DynDynTableEntry {
+    pub const fn new<T: Unsize<D>, D: ?Sized + ~const DynTrait + 'static>() -> DynDynTableEntry {
         DynDynTableEntry {
             ty: DynInfo::of::<D>(),
-            meta: D::meta_for_ty(f),
+            meta: D::meta_for_ty::<T>(),
         }
     }
 


### PR DESCRIPTION
Previously, creating a DynDynTableEntry relied on passing in a closure
that performed a pointer downcast. This was a relic of the time before
dyn-dyn properly made use of the Rust compiler's `unsize` feature.
Because of this, creating a DynDynTableEntry had to be unsafe.

This has now been reworked to use the Unsize trait to perform the
downcast automatically. This eliminates the possibility of passing in a
closure that does not return a pointer with the correct metadata, making
it possible to safely call DynDynTableEntry::new.