### PR TITLE
Rename DynTrait to DynDynCastTarget and implement it for DST structs

### DIFF
--- a/dyn-dyn/src/cast_target.rs
+++ b/dyn-dyn/src/cast_target.rs
@@ -8,7 +8,7 @@ pub struct AnyDynMetadata(*const ());
 
 #[allow(clippy::missing_safety_doc, missing_docs)] // This module is marked doc(hidden)
 impl AnyDynMetadata {
-    pub const unsafe fn downcast<T: DynTrait + ?Sized>(self) -> DynMetadata<T> {
+    pub const unsafe fn downcast<T: DynDynCastTarget + ?Sized>(self) -> DynMetadata<T> {
         mem::transmute(self.0)
     }
 }
@@ -29,7 +29,7 @@ unsafe impl Send for AnyDynMetadata {}
 // SAFETY: Since DynMetadata<T>: Sync for all T, AnyDynMetadata should also be Sync
 unsafe impl Sync for AnyDynMetadata {}
 
-pub trait DynTrait: private::Sealed {
+pub trait DynDynCastTarget: private::Sealed {
     type Root: ?Sized;
 
     fn ptr_into_parts(ptr: NonNull<Self>) -> (NonNull<()>, DynMetadata<Self::Root>);
@@ -38,7 +38,7 @@ pub trait DynTrait: private::Sealed {
     fn meta_for_ty<U: Unsize<Self>>() -> AnyDynMetadata;
 }
 
-impl<M: ?Sized, T: Pointee<Metadata = DynMetadata<M>> + ?Sized> const DynTrait for T {
+impl<M: ?Sized, T: Pointee<Metadata = DynMetadata<M>> + ?Sized> const DynDynCastTarget for T {
     type Root = M;
 
     fn ptr_into_parts(ptr: NonNull<Self>) -> (NonNull<()>, DynMetadata<M>) {

--- a/dyn-dyn/src/fat.rs
+++ b/dyn-dyn/src/fat.rs
@@ -1,4 +1,4 @@
-use crate::{DowncastUnchecked, DynDynBase, DynDynTable, DynTrait, GetDynDynTable};
+use crate::{DowncastUnchecked, DynDynBase, DynDynCastTarget, DynDynTable, GetDynDynTable};
 use core::cmp::Ordering;
 use core::fmt::{self, Display, Pointer};
 use core::hash::{Hash, Hasher};
@@ -115,7 +115,7 @@ impl<'a, B: ?Sized + DynDynBase, P: DowncastUnchecked<'a, B> + 'a> DowncastUnche
 {
     type DowncastResult<D: ?Sized + 'a> = <P as DowncastUnchecked<'a, B>>::DowncastResult<D>;
 
-    unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(
+    unsafe fn downcast_unchecked<D: ?Sized + DynDynCastTarget>(
         self,
         metadata: DynMetadata<D::Root>,
     ) -> Self::DowncastResult<D> {

--- a/dyn-dyn/src/fat.rs
+++ b/dyn-dyn/src/fat.rs
@@ -117,7 +117,7 @@ impl<'a, B: ?Sized + DynDynBase, P: DowncastUnchecked<'a, B> + 'a> DowncastUnche
 
     unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(
         self,
-        metadata: DynMetadata<D>,
+        metadata: DynMetadata<D::Root>,
     ) -> Self::DowncastResult<D> {
         self.ptr.downcast_unchecked(metadata)
     }

--- a/dyn-dyn/src/internal.rs
+++ b/dyn-dyn/src/internal.rs
@@ -1,5 +1,6 @@
 use crate::{
-    DowncastUnchecked, DynDyn, DynDynRef, DynDynRefMut, DynDynTable, DynTrait, GetDynDynTable,
+    DowncastUnchecked, DynDyn, DynDynCastTarget, DynDynRef, DynDynRefMut, DynDynTable,
+    GetDynDynTable,
 };
 use core::marker::{PhantomData, Unsize};
 use core::ops::{Deref, DerefMut};
@@ -44,7 +45,7 @@ pub trait DerefHelperEnd<'a, B: ?Sized + DynDynBase> {
     type Err;
 
     fn get_dyn_dyn_table(&self) -> DynDynTable;
-    unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(
+    unsafe fn downcast_unchecked<D: ?Sized + DynDynCastTarget>(
         self,
         metadata: DynMetadata<D::Root>,
     ) -> <Self::Inner as DowncastUnchecked<'a, B>>::DowncastResult<D>;
@@ -179,7 +180,7 @@ impl<'a, B: ?Sized + DynDynBase, T: DynDyn<'a, B>, E, F: FnOnce(T) -> E> DerefHe
         self.0.get_dyn_dyn_table()
     }
 
-    unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(
+    unsafe fn downcast_unchecked<D: ?Sized + DynDynCastTarget>(
         self,
         metadata: DynMetadata<D::Root>,
     ) -> <Self::Inner as DowncastUnchecked<'a, B>>::DowncastResult<D> {
@@ -195,7 +196,7 @@ impl<'a, B: ?Sized + DynDynBase, T: DynDyn<'a, B>, E, F: FnOnce(T) -> E> DerefHe
     }
 }
 
-pub fn cast_metadata<T: ?Sized + DynTrait, U: ?Sized + DynTrait>(
+pub fn cast_metadata<T: ?Sized + DynDynCastTarget, U: ?Sized + DynDynCastTarget>(
     meta: DynMetadata<T::Root>,
     f: impl Fn(*mut T) -> *mut U,
 ) -> DynMetadata<U::Root> {

--- a/dyn-dyn/src/internal.rs
+++ b/dyn-dyn/src/internal.rs
@@ -46,7 +46,7 @@ pub trait DerefHelperEnd<'a, B: ?Sized + DynDynBase> {
     fn get_dyn_dyn_table(&self) -> DynDynTable;
     unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(
         self,
-        metadata: DynMetadata<D>,
+        metadata: DynMetadata<D::Root>,
     ) -> <Self::Inner as DowncastUnchecked<'a, B>>::DowncastResult<D>;
     fn unwrap(self) -> Self::Inner;
     fn into_err(self) -> Self::Err;
@@ -181,7 +181,7 @@ impl<'a, B: ?Sized + DynDynBase, T: DynDyn<'a, B>, E, F: FnOnce(T) -> E> DerefHe
 
     unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(
         self,
-        metadata: DynMetadata<D>,
+        metadata: DynMetadata<D::Root>,
     ) -> <Self::Inner as DowncastUnchecked<'a, B>>::DowncastResult<D> {
         self.0.downcast_unchecked(metadata)
     }
@@ -196,9 +196,9 @@ impl<'a, B: ?Sized + DynDynBase, T: DynDyn<'a, B>, E, F: FnOnce(T) -> E> DerefHe
 }
 
 pub fn cast_metadata<T: ?Sized + DynTrait, U: ?Sized + DynTrait>(
-    meta: DynMetadata<T>,
+    meta: DynMetadata<T::Root>,
     f: impl Fn(*mut T) -> *mut U,
-) -> DynMetadata<U> {
+) -> DynMetadata<U::Root> {
     U::ptr_into_parts(
         NonNull::new(f(T::ptr_from_parts(NonNull::dangling(), meta).as_ptr())).unwrap(),
     )

--- a/dyn-dyn/src/lib.rs
+++ b/dyn-dyn/src/lib.rs
@@ -221,7 +221,7 @@ pub trait DowncastUnchecked<'a, B: ?Sized + DynDynBase> {
     /// and safe to use before this function can be called.
     unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(
         self,
-        metadata: DynMetadata<D>,
+        metadata: DynMetadata<D::Root>,
     ) -> Self::DowncastResult<D>;
 }
 
@@ -247,7 +247,10 @@ unsafe impl<'a, B: ?Sized + DynDynBase, T: ?Sized + Unsize<B>> GetDynDynTable<B>
 impl<'a, B: ?Sized + DynDynBase, T: ?Sized + Unsize<B>> DowncastUnchecked<'a, B> for &'a T {
     type DowncastResult<D: ?Sized + 'a> = &'a D;
 
-    unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(self, metadata: DynMetadata<D>) -> &'a D {
+    unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(
+        self,
+        metadata: DynMetadata<D::Root>,
+    ) -> &'a D {
         &*D::ptr_from_parts(NonNull::from(self).cast(), metadata).as_ptr()
     }
 }
@@ -276,7 +279,7 @@ where
 
     unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(
         self,
-        metadata: DynMetadata<D>,
+        metadata: DynMetadata<D::Root>,
     ) -> Self::DowncastResult<D> {
         <&T::Target as DowncastUnchecked<B>>::downcast_unchecked(&**self.0, metadata)
     }
@@ -298,7 +301,7 @@ impl<'a, B: ?Sized + DynDynBase, T: ?Sized + Unsize<B>> DowncastUnchecked<'a, B>
 
     unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(
         self,
-        metadata: DynMetadata<D>,
+        metadata: DynMetadata<D::Root>,
     ) -> &'a mut D {
         &mut *D::ptr_from_parts(NonNull::from(self).cast(), metadata).as_ptr()
     }
@@ -328,7 +331,7 @@ where
 
     unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(
         self,
-        metadata: DynMetadata<D>,
+        metadata: DynMetadata<D::Root>,
     ) -> Self::DowncastResult<D> {
         <&mut T::Target as DowncastUnchecked<B>>::downcast_unchecked(&mut **self.0, metadata)
     }
@@ -356,7 +359,7 @@ cfg_if! {
         {
             type DowncastResult<D: ?Sized + 'a> = Box<D>;
 
-            unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(self, metadata: DynMetadata<D>) -> Box<D> {
+            unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(self, metadata: DynMetadata<D::Root>) -> Box<D> {
                 Box::from_raw(
                     D::ptr_from_parts(NonNull::new_unchecked(Box::into_raw(self)).cast(), metadata)
                         .as_ptr(),
@@ -380,7 +383,7 @@ cfg_if! {
         {
             type DowncastResult<D: ?Sized + 'a> = Rc<D>;
 
-            unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(self, metadata: DynMetadata<D>) -> Rc<D> {
+            unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(self, metadata: DynMetadata<D::Root>) -> Rc<D> {
                 Rc::from_raw(
                     D::ptr_from_parts(
                         NonNull::new_unchecked(Rc::into_raw(self) as *mut T).cast(),
@@ -407,7 +410,7 @@ cfg_if! {
         {
             type DowncastResult<D: ?Sized + 'a> = Arc<D>;
 
-            unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(self, metadata: DynMetadata<D>) -> Arc<D> {
+            unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(self, metadata: DynMetadata<D::Root>) -> Arc<D> {
                 Arc::from_raw(
                     D::ptr_from_parts(
                         NonNull::new_unchecked(Arc::into_raw(self) as *mut T).cast(),

--- a/dyn-dyn/src/lib.rs
+++ b/dyn-dyn/src/lib.rs
@@ -17,7 +17,7 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
-mod dyn_trait;
+mod cast_target;
 mod fat;
 mod table;
 
@@ -133,7 +133,7 @@ use core::ops::DerefMut;
 use core::ptr::{DynMetadata, NonNull};
 use stable_deref_trait::StableDeref;
 
-use crate::dyn_trait::DynTrait;
+use crate::cast_target::DynDynCastTarget;
 use internal::*;
 
 /// Wraps a reference to a pointer implementing [`GetDynDynTable<B>`] and which can be dereferenced to perform the downcast.
@@ -219,7 +219,7 @@ pub trait DowncastUnchecked<'a, B: ?Sized + DynDynBase> {
     ///
     /// Attaching the provided metadata to a pointer to the same data address as that held by this pointer must be guaranteed to be valid
     /// and safe to use before this function can be called.
-    unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(
+    unsafe fn downcast_unchecked<D: ?Sized + DynDynCastTarget>(
         self,
         metadata: DynMetadata<D::Root>,
     ) -> Self::DowncastResult<D>;
@@ -247,7 +247,7 @@ unsafe impl<'a, B: ?Sized + DynDynBase, T: ?Sized + Unsize<B>> GetDynDynTable<B>
 impl<'a, B: ?Sized + DynDynBase, T: ?Sized + Unsize<B>> DowncastUnchecked<'a, B> for &'a T {
     type DowncastResult<D: ?Sized + 'a> = &'a D;
 
-    unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(
+    unsafe fn downcast_unchecked<D: ?Sized + DynDynCastTarget>(
         self,
         metadata: DynMetadata<D::Root>,
     ) -> &'a D {
@@ -277,7 +277,7 @@ where
 {
     type DowncastResult<D: ?Sized + 'a> = &'a D;
 
-    unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(
+    unsafe fn downcast_unchecked<D: ?Sized + DynDynCastTarget>(
         self,
         metadata: DynMetadata<D::Root>,
     ) -> Self::DowncastResult<D> {
@@ -299,7 +299,7 @@ unsafe impl<'a, B: ?Sized + DynDynBase, T: ?Sized + Unsize<B>> GetDynDynTable<B>
 impl<'a, B: ?Sized + DynDynBase, T: ?Sized + Unsize<B>> DowncastUnchecked<'a, B> for &'a mut T {
     type DowncastResult<D: ?Sized + 'a> = &'a mut D;
 
-    unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(
+    unsafe fn downcast_unchecked<D: ?Sized + DynDynCastTarget>(
         self,
         metadata: DynMetadata<D::Root>,
     ) -> &'a mut D {
@@ -329,7 +329,7 @@ where
 {
     type DowncastResult<D: ?Sized + 'a> = &'a mut D;
 
-    unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(
+    unsafe fn downcast_unchecked<D: ?Sized + DynDynCastTarget>(
         self,
         metadata: DynMetadata<D::Root>,
     ) -> Self::DowncastResult<D> {
@@ -359,7 +359,7 @@ cfg_if! {
         {
             type DowncastResult<D: ?Sized + 'a> = Box<D>;
 
-            unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(self, metadata: DynMetadata<D::Root>) -> Box<D> {
+            unsafe fn downcast_unchecked<D: ?Sized + DynDynCastTarget>(self, metadata: DynMetadata<D::Root>) -> Box<D> {
                 Box::from_raw(
                     D::ptr_from_parts(NonNull::new_unchecked(Box::into_raw(self)).cast(), metadata)
                         .as_ptr(),
@@ -383,7 +383,7 @@ cfg_if! {
         {
             type DowncastResult<D: ?Sized + 'a> = Rc<D>;
 
-            unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(self, metadata: DynMetadata<D::Root>) -> Rc<D> {
+            unsafe fn downcast_unchecked<D: ?Sized + DynDynCastTarget>(self, metadata: DynMetadata<D::Root>) -> Rc<D> {
                 Rc::from_raw(
                     D::ptr_from_parts(
                         NonNull::new_unchecked(Rc::into_raw(self) as *mut T).cast(),
@@ -410,7 +410,7 @@ cfg_if! {
         {
             type DowncastResult<D: ?Sized + 'a> = Arc<D>;
 
-            unsafe fn downcast_unchecked<D: ?Sized + DynTrait>(self, metadata: DynMetadata<D::Root>) -> Arc<D> {
+            unsafe fn downcast_unchecked<D: ?Sized + DynDynCastTarget>(self, metadata: DynMetadata<D::Root>) -> Arc<D> {
                 Arc::from_raw(
                     D::ptr_from_parts(
                         NonNull::new_unchecked(Arc::into_raw(self) as *mut T).cast(),

--- a/dyn-dyn/src/table.rs
+++ b/dyn-dyn/src/table.rs
@@ -1,4 +1,4 @@
-use crate::dyn_trait::{AnyDynMetadata, DynTrait};
+use crate::cast_target::{AnyDynMetadata, DynDynCastTarget};
 use cfg_if::cfg_if;
 use core::any::TypeId;
 use core::fmt::{self, Debug};
@@ -61,7 +61,8 @@ pub struct DynDynTableEntry {
 
 impl DynDynTableEntry {
     #[doc(hidden)]
-    pub const fn new<T: Unsize<D>, D: ?Sized + ~const DynTrait + 'static>() -> DynDynTableEntry {
+    pub const fn new<T: Unsize<D>, D: ?Sized + ~const DynDynCastTarget + 'static>(
+    ) -> DynDynTableEntry {
         DynDynTableEntry {
             ty: DynInfo::of::<D>(),
             meta: D::meta_for_ty::<T>(),
@@ -113,7 +114,7 @@ impl DynDynTable {
     }
 
     /// Finds the metadata corresponding to the trait `D` in this table or `None` if no such metadata is present.
-    pub fn find<D: ?Sized + DynTrait + 'static>(&self) -> Option<DynMetadata<D>> {
+    pub fn find<D: ?Sized + DynDynCastTarget + 'static>(&self) -> Option<DynMetadata<D>> {
         self.find_untyped(TypeId::of::<D>()).map(|meta| {
             // SAFETY: This metadata corresponds to the trait D, so we can downcast it
             unsafe { meta.downcast() }


### PR DESCRIPTION
Previously, the `DynTrait` trait was being used to actually be able to perform metadata-related operations on fat pointers. This struct was implemented only for pointees where their `DynMetadata` type matched their actual type, which is the case for all trait objects. However, this is not the case for DST structs: their `DynMetadata` type is actually the inner trait object type.

In order to not preclude the handling of DST structs in the future, `DynTrait` has been renamed to `DynDynCastTarget` (which better represents its actual purpose) and has been implemented for pointees that have any `DynMetadata` type for their metadata.