### PR TITLE
Change DynDynCastTarget::meta_for_ty to return typed metadata

### DIFF
--- a/dyn-dyn/src/cast_target.rs
+++ b/dyn-dyn/src/cast_target.rs
@@ -35,7 +35,7 @@ pub trait DynDynCastTarget: private::Sealed {
     fn ptr_into_parts(ptr: NonNull<Self>) -> (NonNull<()>, DynMetadata<Self::Root>);
     fn ptr_from_parts(data: NonNull<()>, meta: DynMetadata<Self::Root>) -> NonNull<Self>;
 
-    fn meta_for_ty<U: Unsize<Self>>() -> AnyDynMetadata;
+    fn meta_for_ty<U: Unsize<Self>>() -> DynMetadata<Self::Root>;
 }
 
 impl<M: ?Sized, T: Pointee<Metadata = DynMetadata<M>> + ?Sized> const DynDynCastTarget for T {
@@ -50,8 +50,8 @@ impl<M: ?Sized, T: Pointee<Metadata = DynMetadata<M>> + ?Sized> const DynDynCast
         unsafe { NonNull::new_unchecked(ptr::from_raw_parts_mut(data.as_ptr(), meta)) }
     }
 
-    fn meta_for_ty<U: Unsize<Self>>() -> AnyDynMetadata {
-        ptr::metadata(ptr::null::<U>() as *const Self).into()
+    fn meta_for_ty<U: Unsize<Self>>() -> DynMetadata<M> {
+        ptr::metadata(ptr::null::<U>() as *const Self)
     }
 }
 

--- a/dyn-dyn/src/table.rs
+++ b/dyn-dyn/src/table.rs
@@ -65,7 +65,7 @@ impl DynDynTableEntry {
     ) -> DynDynTableEntry {
         DynDynTableEntry {
             ty: DynInfo::of::<D>(),
-            meta: D::meta_for_ty::<T>(),
+            meta: D::meta_for_ty::<T>().into(),
         }
     }
 


### PR DESCRIPTION
Previously, the DynDynCastTarget::meta_for_ty method would return
AnyDynMetadata. This was suboptimal, since the actual type of this
metadata is statically known. The cast to AnyDynMetadata has now been
removed to DynDynTableEntry::new, where it actually belongs.