### PR TITLE
Export some types that are part of the public API

### DIFF
--- a/dyn-dyn-macros/src/base.rs
+++ b/dyn-dyn-macros/src/base.rs
@@ -56,7 +56,7 @@ pub fn dyn_dyn_base(_args: TokenStream, mut input: ItemTrait) -> TokenStream {
             fn __dyn_dyn_get_table(&self) -> ::dyn_dyn::DynDynTable { <Self as ::dyn_dyn::internal::DynDynDerived<dyn #ident #type_generics>>::get_dyn_dyn_table(self) }
         }
 
-        unsafe impl #impl_generics ::dyn_dyn::internal::DynDynBase for dyn #ident #type_generics + '__dyn_dyn_lifetime #where_clause {
+        unsafe impl #impl_generics ::dyn_dyn::DynDynBase for dyn #ident #type_generics + '__dyn_dyn_lifetime #where_clause {
             fn get_dyn_dyn_table(&self) -> ::dyn_dyn::DynDynTable { <Self as #base_trait_ident #type_generics>::__dyn_dyn_get_table(self) }
         }
     };

--- a/dyn-dyn/src/cast_target.rs
+++ b/dyn-dyn/src/cast_target.rs
@@ -1,12 +1,18 @@
 use core::marker::Unsize;
 use core::ptr::{self, DynMetadata, NonNull, Pointee};
 
+/// A type whose pointer metadata can be stored in a [`DynDynTable`](crate::DynDynTable).
 pub trait DynDynCastTarget: private::Sealed {
+    /// The root type that the trait object metadata is for.
     type Root: ?Sized;
 
+    /// Splits a fat pointer into its data pointer and metadata.
     fn ptr_into_parts(ptr: NonNull<Self>) -> (NonNull<()>, DynMetadata<Self::Root>);
+
+    /// Combines a data pointer with the provided metadata to produce a fat pointer.
     fn ptr_from_parts(data: NonNull<()>, meta: DynMetadata<Self::Root>) -> NonNull<Self>;
 
+    /// Gets the metadata that would be used for an object of concrete type `U` when cast to this type.
     fn meta_for_ty<U: Unsize<Self>>() -> DynMetadata<Self::Root>;
 }
 

--- a/dyn-dyn/src/cast_target.rs
+++ b/dyn-dyn/src/cast_target.rs
@@ -1,33 +1,5 @@
 use core::marker::Unsize;
-use core::ptr::{DynMetadata, NonNull, Pointee};
-use core::{mem, ptr};
-
-#[derive(Debug, Clone, Copy)]
-#[allow(missing_docs)]
-pub struct AnyDynMetadata(*const ());
-
-#[allow(clippy::missing_safety_doc, missing_docs)] // This module is marked doc(hidden)
-impl AnyDynMetadata {
-    pub const unsafe fn downcast<T: DynDynCastTarget + ?Sized>(self) -> DynMetadata<T> {
-        mem::transmute(self.0)
-    }
-}
-
-impl<T: ?Sized> const From<DynMetadata<T>> for AnyDynMetadata {
-    fn from(meta: DynMetadata<T>) -> Self {
-        // SAFETY: There are no invalid values for *const (), so transmuting to it should never cause UB if DynMetadata<T> is of the same
-        //         size. The only valid usage of this *const () is then to transmute it back to DynMetadata<T>. While this definitely makes
-        //         assumptions about how the standard library implements DynMetadata (which is unfortunate), we should fail to compile if
-        //         that changes rather than invoking UB.
-        unsafe { AnyDynMetadata(mem::transmute(meta)) }
-    }
-}
-
-// SAFETY: Since DynMetadata<T>: Send for all T, AnyDynMetadata should also be Send
-unsafe impl Send for AnyDynMetadata {}
-
-// SAFETY: Since DynMetadata<T>: Sync for all T, AnyDynMetadata should also be Sync
-unsafe impl Sync for AnyDynMetadata {}
+use core::ptr::{self, DynMetadata, NonNull, Pointee};
 
 pub trait DynDynCastTarget: private::Sealed {
     type Root: ?Sized;

--- a/dyn-dyn/src/internal.rs
+++ b/dyn-dyn/src/internal.rs
@@ -1,5 +1,5 @@
 use crate::{
-    DowncastUnchecked, DynDyn, DynDynCastTarget, DynDynRef, DynDynRefMut, DynDynTable,
+    DowncastUnchecked, DynDyn, DynDynBase, DynDynCastTarget, DynDynRef, DynDynRefMut, DynDynTable,
     GetDynDynTable,
 };
 use core::marker::{PhantomData, Unsize};
@@ -10,11 +10,6 @@ use stable_deref_trait::StableDeref;
 
 #[allow(clippy::missing_safety_doc)] // This module is marked doc(hidden)
 pub unsafe trait DynDynDerived<B: ?Sized + DynDynBase> {
-    fn get_dyn_dyn_table(&self) -> DynDynTable;
-}
-
-#[allow(clippy::missing_safety_doc)] // This module is marked doc(hidden)
-pub unsafe trait DynDynBase {
     fn get_dyn_dyn_table(&self) -> DynDynTable;
 }
 

--- a/dyn-dyn/src/lib.rs
+++ b/dyn-dyn/src/lib.rs
@@ -121,8 +121,9 @@ pub use dyn_dyn_macros::dyn_dyn_cast;
 /// ```
 pub use dyn_dyn_macros::dyn_dyn_derived;
 
+pub use cast_target::DynDynCastTarget;
 pub use fat::DynDynFat;
-pub use table::{DynDynTable, DynDynTableEntry, DynDynTableIterator};
+pub use table::{AnyDynMetadata, DynDynTable, DynDynTableEntry, DynDynTableIterator};
 
 #[cfg(doc)]
 use core::ops::Deref;
@@ -133,8 +134,23 @@ use core::ops::DerefMut;
 use core::ptr::{DynMetadata, NonNull};
 use stable_deref_trait::StableDeref;
 
-use crate::cast_target::DynDynCastTarget;
-use internal::*;
+/// A type that can be dynamically downcast to other traits using the [`dyn_dyn_cast!`] macro.
+///
+/// This trait should not be manually implemented by user code. Instead, this trait should be implemented by using the [`#[dyn_dyn_base]`]
+/// attribute on the trait in question. The exact shape of this trait is subject to change at any time, so it generally shouldn't be relied
+/// upon in external code.
+///
+/// # Safety
+///
+/// The result of calling [`DynDynBase::get_dyn_dyn_table`] on an object through a given base must never change for the lifetime of that
+/// object, even if the object itself is mutated.
+pub unsafe trait DynDynBase {
+    /// Gets the [`DynDynTable`] for this object, for traits exposed via this base trait.
+    ///
+    /// In user code, it is generally preferred to use the implementation of [`GetDynDynTable`] for references rather than calling this
+    /// method directly to avoid potential future breakage.
+    fn get_dyn_dyn_table(&self) -> DynDynTable;
+}
 
 /// Wraps a reference to a pointer implementing [`GetDynDynTable<B>`] and which can be dereferenced to perform the downcast.
 ///

--- a/dyn-dyn/src/table.rs
+++ b/dyn-dyn/src/table.rs
@@ -1,12 +1,40 @@
-use crate::cast_target::{AnyDynMetadata, DynDynCastTarget};
+use crate::cast_target::DynDynCastTarget;
 use cfg_if::cfg_if;
 use core::any::TypeId;
 use core::fmt::{self, Debug};
 use core::marker::Unsize;
+use core::mem;
 use core::ptr::DynMetadata;
 
 #[cfg(doc)]
 use crate::dyn_dyn_cast;
+
+#[derive(Debug, Clone, Copy)]
+#[allow(missing_docs)]
+pub struct AnyDynMetadata(*const ());
+
+#[allow(clippy::missing_safety_doc, missing_docs)] // This module is marked doc(hidden)
+impl AnyDynMetadata {
+    pub const unsafe fn downcast<T: DynDynCastTarget + ?Sized>(self) -> DynMetadata<T> {
+        mem::transmute(self.0)
+    }
+}
+
+impl<T: ?Sized> const From<DynMetadata<T>> for AnyDynMetadata {
+    fn from(meta: DynMetadata<T>) -> Self {
+        // SAFETY: There are no invalid values for *const (), so transmuting to it should never cause UB if DynMetadata<T> is of the same
+        //         size. The only valid usage of this *const () is then to transmute it back to DynMetadata<T>. While this definitely makes
+        //         assumptions about how the standard library implements DynMetadata (which is unfortunate), we should fail to compile if
+        //         that changes rather than invoking UB.
+        unsafe { AnyDynMetadata(mem::transmute(meta)) }
+    }
+}
+
+// SAFETY: Since DynMetadata<T>: Send for all T, AnyDynMetadata should also be Send
+unsafe impl Send for AnyDynMetadata {}
+
+// SAFETY: Since DynMetadata<T>: Sync for all T, AnyDynMetadata should also be Sync
+unsafe impl Sync for AnyDynMetadata {}
 
 cfg_if! {
     if #[cfg(feature = "dynamic-names")] {

--- a/dyn-dyn/src/table.rs
+++ b/dyn-dyn/src/table.rs
@@ -9,12 +9,16 @@ use core::ptr::DynMetadata;
 #[cfg(doc)]
 use crate::dyn_dyn_cast;
 
+/// An untyped metadata that corresponds to the metadata that would be used for a trait object.
 #[derive(Debug, Clone, Copy)]
-#[allow(missing_docs)]
 pub struct AnyDynMetadata(*const ());
 
-#[allow(clippy::missing_safety_doc, missing_docs)] // This module is marked doc(hidden)
 impl AnyDynMetadata {
+    /// Downcasts this untyped metadata into typed metadata for a trait object referring to a particular trait.
+    ///
+    /// # Safety
+    ///
+    /// This untyped metadata must have originally been constructed by converting a `DynMetadata<T>`.
     pub const unsafe fn downcast<T: DynDynCastTarget + ?Sized>(self) -> DynMetadata<T> {
         mem::transmute(self.0)
     }

--- a/dyn-dyn/tests/fat.rs
+++ b/dyn-dyn/tests/fat.rs
@@ -6,8 +6,7 @@ use alloc::boxed::Box;
 use alloc::rc::Rc;
 use core::cell::Cell;
 use core::ops::Deref;
-use dyn_dyn::internal::DynDynBase;
-use dyn_dyn::{dyn_dyn_cast, DynDynFat, DynDynTable, DynDynTableEntry, GetDynDynTable};
+use dyn_dyn::{dyn_dyn_cast, DynDynBase, DynDynFat, DynDynTable, DynDynTableEntry, GetDynDynTable};
 use stable_deref_trait::StableDeref;
 
 // We need the pointers to these two tables to be distinct in order to properly differentiate them, so these cannot be declared as


### PR DESCRIPTION
Previously, the DynDynBase and DynDynDowncastTarget traits, as well as
the AnyDynMetadata struct, were not exported publicly for users to use.
This was strange, since these types are prominently used in several
public APIs.

In the case of DynDynDowncastTarget and AnyDynMetadata, these types were
declared in private modules and never re-exported. Because of this, it
was impossible for user code to even name them, which limited how
several public APIs could be used.

In the case of the DynDynBase trait, this trait *could* technically be
accessed by external code by going through the undocumented `internal`
module (so that the procedural macros can name it), but had no
documentation and no stable way of referring to it.

In order to make using dyn-dyn easier, these types are now exported
publicly in the root of the crate so that user code can name them.