### PR TITLE
Rename dyn_dyn_derived to dyn_dyn_impl

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 
 ## Usage
 
-`dyn-dyn` is used by declaring a "base trait" annotated with the `#[dyn_dyn_base]` attribute macro and annotating any `impl` blocks for that trait using the `#[dyn_dyn_derived(...)]` attribute macro. Any reference to the base trait can then be downcast to a reference to the derived trait by using the `dyn_dyn_cast!` macro, like so: 
+`dyn-dyn` is used by declaring a "base trait" annotated with the `#[dyn_dyn_base]` attribute macro and annotating any `impl` blocks for that trait using the `#[dyn_dyn_impl(...)]` attribute macro. Any reference to the base trait can then be downcast to a reference to the derived trait by using the `dyn_dyn_cast!` macro, like so:
 
 ```rust
-use dyn_dyn::{dyn_dyn_base, dyn_dyn_cast, dyn_dyn_derived};
+use dyn_dyn::{dyn_dyn_base, dyn_dyn_cast, dyn_dyn_impl};
 
 #[dyn_dyn_base]
 trait BaseTrait {}
@@ -19,7 +19,7 @@ struct Struct;
 
 impl ExposedTrait for Struct {}
 
-#[dyn_dyn_derived(ExposedTrait)]
+#[dyn_dyn_impl(ExposedTrait)]
 impl BaseTrait for Struct {}
 
 fn main() {
@@ -43,7 +43,7 @@ Currently, `dyn-dyn` only works in nightly versions of Rust due to its use of th
 
 Due to limitations of `TypeId`, `dyn-dyn` can only currently work with types and traits that are `'static`.
 
-In order to be able to construct a way of downcasting into every possible derived trait that a concrete type wishes to expose, the set of traits exposed using the `#[dyn_dyn_derived(...)]` attribute must be finite. That is, it is not possible to expose some generic trait `Trait<T>` for an arbitrary value of `T` (although it is possible to do so if `T` is constrained by a generic argument to the concrete type itself).
+In order to be able to construct a way of downcasting into every possible derived trait that a concrete type wishes to expose, the set of traits exposed using the `#[dyn_dyn_impl(...)]` attribute must be finite. That is, it is not possible to expose some generic trait `Trait<T>` for an arbitrary value of `T` (although it is possible to do so if `T` is constrained by a generic argument to the concrete type or base trait).
 
 ## How it works
 

--- a/dyn-dyn-macros/src/base.rs
+++ b/dyn-dyn-macros/src/base.rs
@@ -31,7 +31,9 @@ pub fn dyn_dyn_base(_args: TokenStream, mut input: ItemTrait) -> TokenStream {
     let base_trait_ident = format_ident!("__dyn_dyn_{}_Base", ident);
     let mut base_trait_impl_generics = generics.clone();
 
-    base_trait_impl_generics.params.push(syn::parse2(quote!(__dyn_dyn_T: ?Sized + ::dyn_dyn::internal::DynDynDerived<dyn #ident #type_generics>)).unwrap());
+    base_trait_impl_generics.params.push(syn::parse2(
+        quote!(__dyn_dyn_T: ?Sized + ::dyn_dyn::internal::DynDynImpl<dyn #ident #type_generics>)).unwrap()
+    );
 
     let mut dyn_dyn_base_generics = generics.clone();
     dyn_dyn_base_generics
@@ -53,11 +55,15 @@ pub fn dyn_dyn_base(_args: TokenStream, mut input: ItemTrait) -> TokenStream {
         }
 
         unsafe impl #base_trait_impl_generics #base_trait_ident #type_generics for __dyn_dyn_T #where_clause {
-            fn __dyn_dyn_get_table(&self) -> ::dyn_dyn::DynDynTable { <Self as ::dyn_dyn::internal::DynDynDerived<dyn #ident #type_generics>>::get_dyn_dyn_table(self) }
+            fn __dyn_dyn_get_table(&self) -> ::dyn_dyn::DynDynTable {
+                <Self as ::dyn_dyn::internal::DynDynImpl<dyn #ident #type_generics>>::get_dyn_dyn_table(self)
+            }
         }
 
         unsafe impl #impl_generics ::dyn_dyn::DynDynBase for dyn #ident #type_generics + '__dyn_dyn_lifetime #where_clause {
-            fn get_dyn_dyn_table(&self) -> ::dyn_dyn::DynDynTable { <Self as #base_trait_ident #type_generics>::__dyn_dyn_get_table(self) }
+            fn get_dyn_dyn_table(&self) -> ::dyn_dyn::DynDynTable {
+                <Self as #base_trait_ident #type_generics>::__dyn_dyn_get_table(self)
+            }
         }
     };
 

--- a/dyn-dyn-macros/src/impl_block.rs
+++ b/dyn-dyn-macros/src/impl_block.rs
@@ -5,12 +5,12 @@ use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::{GenericParam, ItemImpl, Token, Type};
 
-pub fn dyn_dyn_derived(args: Punctuated<Type, Token![,]>, input: ItemImpl) -> TokenStream {
+pub fn dyn_dyn_impl(args: Punctuated<Type, Token![,]>, input: ItemImpl) -> TokenStream {
     if input.trait_.is_none() {
         Diagnostic::spanned(
             proc_macro::Span::call_site(),
             Level::Error,
-            "Cannot use dyn_dyn_derived on an inherent impl block",
+            "Cannot use dyn_dyn_impl on an inherent impl block",
         )
         .emit();
         return input.to_token_stream();
@@ -18,7 +18,7 @@ pub fn dyn_dyn_derived(args: Punctuated<Type, Token![,]>, input: ItemImpl) -> To
         Diagnostic::spanned(
             proc_macro::Span::call_site(),
             Level::Error,
-            "Cannot use dyn_dyn_derived on a negative impl block",
+            "Cannot use dyn_dyn_impl on a negative impl block",
         )
         .emit();
         return input.to_token_stream();
@@ -79,7 +79,7 @@ pub fn dyn_dyn_derived(args: Punctuated<Type, Token![,]>, input: ItemImpl) -> To
             ];
         }
 
-        unsafe impl #impl_generics ::dyn_dyn::internal::DynDynDerived<dyn #trait_> for #self_ty #where_clause {
+        unsafe impl #impl_generics ::dyn_dyn::internal::DynDynImpl<dyn #trait_> for #self_ty #where_clause {
             fn get_dyn_dyn_table(&self) -> ::dyn_dyn::DynDynTable {
                 ::dyn_dyn::DynDynTable::new(&#table_ident #turbo_tok #type_generics::__TABLE[..])
             }

--- a/dyn-dyn-macros/src/lib.rs
+++ b/dyn-dyn-macros/src/lib.rs
@@ -13,7 +13,7 @@ use syn::{parse_macro_input, ItemImpl, ItemTrait, Token, Type};
 
 mod base;
 mod cast;
-mod derived;
+mod impl_block;
 
 #[proc_macro]
 pub fn dyn_dyn_cast(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
@@ -37,11 +37,11 @@ impl Parse for DerivedTypes {
 }
 
 #[proc_macro_attribute]
-pub fn dyn_dyn_derived(
+pub fn dyn_dyn_impl(
     args: proc_macro::TokenStream,
     input: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
-    derived::dyn_dyn_derived(
+    impl_block::dyn_dyn_impl(
         parse_macro_input!(args as DerivedTypes).0,
         parse_macro_input!(input as ItemImpl),
     )

--- a/dyn-dyn/src/internal.rs
+++ b/dyn-dyn/src/internal.rs
@@ -9,7 +9,7 @@ use core::ptr::NonNull;
 use stable_deref_trait::StableDeref;
 
 #[allow(clippy::missing_safety_doc)] // This module is marked doc(hidden)
-pub unsafe trait DynDynDerived<B: ?Sized + DynDynBase> {
+pub unsafe trait DynDynImpl<B: ?Sized + DynDynBase> {
     fn get_dyn_dyn_table(&self) -> DynDynTable;
 }
 

--- a/dyn-dyn/src/lib.rs
+++ b/dyn-dyn/src/lib.rs
@@ -27,7 +27,7 @@ pub mod internal;
 /// Declares a trait as being a base trait for downcasting.
 ///
 /// This macro marks a trait as being a base for dynamic trait object downcasting. All `impl` blocks for this trait will need to use the
-/// [`#[dyn_dyn_derived]`](dyn_dyn_derived) attribute to declare what traits they wish to expose.
+/// [`#[dyn_dyn_impl]`](dyn_dyn_impl) attribute to declare what traits they wish to expose.
 pub use dyn_dyn_macros::dyn_dyn_base;
 
 /// Performs a dynamic downcast of a reference to a trait object where the trait was declared with [`#[dyn_dyn_base]`](dyn_dyn_base).
@@ -48,14 +48,14 @@ pub use dyn_dyn_macros::dyn_dyn_base;
 /// # Examples
 ///
 /// ```rust
-/// # use dyn_dyn::{dyn_dyn_base, dyn_dyn_cast, dyn_dyn_derived};
+/// # use dyn_dyn::{dyn_dyn_base, dyn_dyn_cast, dyn_dyn_impl};
 /// #[dyn_dyn_base]
 /// trait Base {}
 /// trait Trait {}
 ///
 /// struct Struct;
 ///
-/// #[dyn_dyn_derived(Trait)]
+/// #[dyn_dyn_impl(Trait)]
 /// impl Base for Struct {}
 /// impl Trait for Struct {}
 ///
@@ -95,19 +95,19 @@ pub use dyn_dyn_macros::dyn_dyn_cast;
 ///
 /// ```rust
 /// # use core::fmt::Debug;
-/// # use dyn_dyn::{dyn_dyn_base, dyn_dyn_derived};
+/// # use dyn_dyn::{dyn_dyn_base, dyn_dyn_impl};
 /// #[dyn_dyn_base]
 /// trait Base {}
 ///
 /// #[derive(Debug)]
 /// struct Struct;
 ///
-/// #[dyn_dyn_derived(Debug)]
+/// #[dyn_dyn_impl(Debug)]
 /// impl Base for Struct {}
 /// ```
 ///
 /// ```rust
-/// # use dyn_dyn::{dyn_dyn_base, dyn_dyn_derived};
+/// # use dyn_dyn::{dyn_dyn_base, dyn_dyn_impl};
 /// #[dyn_dyn_base]
 /// trait Base {}
 /// trait Trait<T> {}
@@ -116,10 +116,10 @@ pub use dyn_dyn_macros::dyn_dyn_cast;
 ///
 /// impl<T> Trait<T> for Struct<T> {}
 ///
-/// #[dyn_dyn_derived(Trait<T>)]
+/// #[dyn_dyn_impl(Trait<T>)]
 /// impl<T: 'static> Base for Struct<T> {}
 /// ```
-pub use dyn_dyn_macros::dyn_dyn_derived;
+pub use dyn_dyn_macros::dyn_dyn_impl;
 
 pub use cast_target::DynDynCastTarget;
 pub use fat::DynDynFat;

--- a/dyn-dyn/tests/basics.rs
+++ b/dyn-dyn/tests/basics.rs
@@ -1,4 +1,4 @@
-use dyn_dyn::{dyn_dyn_base, dyn_dyn_cast, dyn_dyn_derived};
+use dyn_dyn::{dyn_dyn_base, dyn_dyn_cast, dyn_dyn_impl};
 use std::fmt;
 use std::rc::Rc;
 
@@ -21,7 +21,7 @@ fn test_vtable_correct() {
 
     struct TestStruct;
 
-    #[dyn_dyn_derived(SubTraitA, SubTraitB)]
+    #[dyn_dyn_impl(SubTraitA, SubTraitB)]
     impl Base for TestStruct {}
 
     impl SubTraitA for TestStruct {
@@ -90,7 +90,7 @@ fn test_data_pointer_correct() {
 
     struct TestStruct;
 
-    #[dyn_dyn_derived(TestTrait)]
+    #[dyn_dyn_impl(TestTrait)]
     impl Base for TestStruct {}
 
     impl TestTrait for TestStruct {
@@ -129,7 +129,7 @@ fn test_from_alloc() {
 
     struct TestStruct;
 
-    #[dyn_dyn_derived(TestTrait)]
+    #[dyn_dyn_impl(TestTrait)]
     impl Base for TestStruct {}
 
     impl TestTrait for TestStruct {
@@ -171,7 +171,7 @@ fn test_external_trait() {
 
     struct TestStruct(&'static str);
 
-    #[dyn_dyn_derived(fmt::Debug)]
+    #[dyn_dyn_impl(fmt::Debug)]
     impl Base for TestStruct {}
 
     impl fmt::Debug for TestStruct {
@@ -194,7 +194,7 @@ fn test_external_type() {
     trait Base {}
     trait TestTrait {}
 
-    #[dyn_dyn_derived(TestTrait)]
+    #[dyn_dyn_impl(TestTrait)]
     impl Base for u32 {}
     impl TestTrait for u32 {}
 
@@ -213,11 +213,11 @@ fn test_multi_base() {
 
     struct TestStruct;
 
-    #[dyn_dyn_derived(TraitA)]
+    #[dyn_dyn_impl(TraitA)]
     impl BaseA for TestStruct {}
     impl TraitA for TestStruct {}
 
-    #[dyn_dyn_derived(TraitB)]
+    #[dyn_dyn_impl(TraitB)]
     impl BaseB for TestStruct {}
     impl TraitB for TestStruct {}
 
@@ -236,7 +236,7 @@ fn test_temporaries_extended() {
 
     struct TestStruct;
 
-    #[dyn_dyn_derived(Trait)]
+    #[dyn_dyn_impl(Trait)]
     impl Base for TestStruct {}
     impl Trait for TestStruct {}
 

--- a/dyn-dyn/tests/generics.rs
+++ b/dyn-dyn/tests/generics.rs
@@ -1,4 +1,4 @@
-use dyn_dyn::{dyn_dyn_base, dyn_dyn_cast, dyn_dyn_derived};
+use dyn_dyn::{dyn_dyn_base, dyn_dyn_cast, dyn_dyn_impl};
 
 #[test]
 fn test_generic_base() {
@@ -10,10 +10,10 @@ fn test_generic_base() {
 
     struct TestStruct;
 
-    #[dyn_dyn_derived(TestTraitA)]
+    #[dyn_dyn_impl(TestTraitA)]
     impl Base<u32> for TestStruct {}
 
-    #[dyn_dyn_derived(TestTraitB)]
+    #[dyn_dyn_impl(TestTraitB)]
     impl Base<u64> for TestStruct {}
 
     impl TestTraitA for TestStruct {}
@@ -37,7 +37,7 @@ fn test_generic_trait() {
 
     struct TestStruct;
 
-    #[dyn_dyn_derived(GenericTrait<u32>, GenericTrait<u64>)]
+    #[dyn_dyn_impl(GenericTrait<u32>, GenericTrait<u64>)]
     impl Base for TestStruct {}
     impl GenericTrait<u32> for TestStruct {
         fn test(&self) -> u32 {
@@ -81,7 +81,7 @@ fn test_generic_trait_from_param() {
 
     struct TestStruct<T: 'static>(T);
 
-    #[dyn_dyn_derived(GenericTrait<T>)]
+    #[dyn_dyn_impl(GenericTrait<T>)]
     impl<T: 'static> Base for TestStruct<T> {}
 
     impl<T: 'static> GenericTrait<T> for TestStruct<T> {
@@ -125,7 +125,7 @@ fn test_generic_base_from_param() {
 
     struct TestStruct<T: 'static>(T);
 
-    #[dyn_dyn_derived(TestTrait<T>)]
+    #[dyn_dyn_impl(TestTrait<T>)]
     impl<T: 'static> Base<T> for TestStruct<T> {}
     impl<T: 'static> TestTrait<T> for TestStruct<T> {}
 
@@ -151,7 +151,7 @@ fn test_generic_base_blanket_impl() {
 
     struct TestStruct;
 
-    #[dyn_dyn_derived(TestTrait<T>)]
+    #[dyn_dyn_impl(TestTrait<T>)]
     impl<T: 'static> Base<T> for TestStruct {}
     impl<T: 'static> TestTrait<T> for TestStruct {}
 
@@ -173,7 +173,7 @@ fn test_where_clause_on_base() {
 
     struct TestStruct;
 
-    #[dyn_dyn_derived(TestTrait)]
+    #[dyn_dyn_impl(TestTrait)]
     impl Base<u32> for TestStruct {}
     impl TestTrait for TestStruct {}
 
@@ -193,7 +193,7 @@ fn test_where_clause_on_derived() {
     where
         T: 'static;
 
-    #[dyn_dyn_derived(GenericTrait<T>)]
+    #[dyn_dyn_impl(GenericTrait<T>)]
     impl<T> Base for TestStruct<T> where T: 'static {}
 
     impl<T: 'static> GenericTrait<T> for TestStruct<T> {

--- a/dyn-dyn/tests/send_sync.rs
+++ b/dyn-dyn/tests/send_sync.rs
@@ -1,4 +1,4 @@
-use dyn_dyn::{dyn_dyn_base, dyn_dyn_cast, dyn_dyn_derived};
+use dyn_dyn::{dyn_dyn_base, dyn_dyn_cast, dyn_dyn_impl};
 
 #[dyn_dyn_base]
 trait BaseTrait {}
@@ -8,7 +8,7 @@ trait TestTrait {
 
 struct TestStruct;
 
-#[dyn_dyn_derived(TestTrait)]
+#[dyn_dyn_impl(TestTrait)]
 impl BaseTrait for TestStruct {}
 impl TestTrait for TestStruct {
     fn test(&self) -> u32 {


### PR DESCRIPTION
In order to better reflect its purpose and to use more idiomatic Rust
language, the dyn_dyn_derived attribute macro has been renamed to
dyn_dyn_impl.