### PR TITLE
Include all features in docs.rs documentation

### DIFF
--- a/dyn-dyn-macros/Cargo.toml
+++ b/dyn-dyn-macros/Cargo.toml
@@ -7,6 +7,9 @@ version = "0.1.0"
 authors = ["Benjamin Thomas <ben@benthomas.ca>"]
 edition = "2021"
 
+[package.metadata.docs.rs]
+all-features = true
+
 [lib]
 proc-macro = true
 


### PR DESCRIPTION
Previously, the documentation generated by docs.rs only contained APIs
made available by the default features. Specifically, APIs guarded under
the dynamic-names feature were not included. Telling docs.rs to generate
documentation for all features in Cargo.toml should correct this.