### PR TITLE
Include all features in docs.rs documentation (for real this time)

### DIFF
--- a/dyn-dyn/Cargo.toml
+++ b/dyn-dyn/Cargo.toml
@@ -10,6 +10,9 @@ version = "0.1.0"
 authors = ["Benjamin Thomas <ben@benthomas.ca>"]
 edition = "2021"
 
+[package.metadata.docs.rs]
+all-features = true
+
 [features]
 alloc = ["stable_deref_trait/alloc"]
 default = ["std"]


### PR DESCRIPTION
The previous commit to make docs.rs generate documentation for all
features accidentally only included the change to dyn-dyn-macros's
Cargo.toml. This commit corrects that and includes the same change for
dyn-dyn itself.