### PR TITLE
Allow dyn_dyn_cast! to be used with wrapped DST types

### DIFF
--- a/dyn-dyn-macros/src/cast.rs
+++ b/dyn-dyn-macros/src/cast.rs
@@ -1,10 +1,11 @@
 use proc_macro::{Diagnostic, Level};
-use proc_macro2::{Span, TokenStream};
-use quote::quote;
+use proc_macro2::{Delimiter, Group, Span, TokenStream, TokenTree};
+use quote::{quote, TokenStreamExt};
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
-use syn::{Expr, Token, TraitBound, TypeParamBound};
+use syn::token::Bracket;
+use syn::{bracketed, Expr, Token, TraitBound, Type, TypeParamBound};
 
 #[derive(Copy, Clone)]
 pub enum DynDynCastType {
@@ -18,12 +19,15 @@ pub struct DynDynCastInput {
     base_traits: Punctuated<TypeParamBound, Token![+]>,
     _arrow: Token![=>],
     target_traits: Punctuated<TypeParamBound, Token![+]>,
+    outer_struct: Option<(Bracket, TokenStream)>,
     _comma: Token![,],
     expr: Expr,
 }
 
 impl Parse for DynDynCastInput {
     fn parse(input: ParseStream) -> syn::Result<Self> {
+        let outer_struct;
+
         Ok(DynDynCastInput {
             ty: if let Some(tok) = input.parse::<Option<Token![mut]>>()? {
                 DynDynCastType::Mut(tok)
@@ -35,6 +39,11 @@ impl Parse for DynDynCastInput {
             base_traits: Punctuated::parse_separated_nonempty(input)?,
             _arrow: input.parse()?,
             target_traits: Punctuated::parse_separated_nonempty(input)?,
+            outer_struct: if input.peek(Bracket) {
+                Some((bracketed!(outer_struct in input), outer_struct.parse()?))
+            } else {
+                None
+            },
             _comma: input.parse()?,
             expr: input.parse()?,
         })
@@ -48,6 +57,7 @@ struct DynDynCastProcessedInput {
     base_markers: Vec<TypeParamBound>,
     tgt_primary_trait: TraitBound,
     tgt_markers: Vec<TypeParamBound>,
+    outer_struct: Option<TokenStream>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -79,7 +89,55 @@ fn process_input(input: &DynDynCastInput) -> Result<DynDynCastProcessedInput, (S
         base_markers,
         tgt_primary_trait,
         tgt_markers,
+        outer_struct: input
+            .outer_struct
+            .as_ref()
+            .map(|&(_, ref outer_struct)| outer_struct.clone()),
     })
+}
+
+fn replace_placeholder(input: Option<TokenStream>, val: TokenStream) -> Result<TokenStream, ()> {
+    fn replace_placeholder_impl(
+        input: TokenStream,
+        val: &mut Option<TokenStream>,
+    ) -> Result<TokenStream, ()> {
+        let mut out = TokenStream::new();
+
+        for tt in input {
+            let tt = match tt {
+                TokenTree::Group(group) => TokenTree::Group(Group::new(
+                    group.delimiter(),
+                    replace_placeholder_impl(group.stream(), val)?,
+                )),
+                TokenTree::Punct(ref p) if p.as_char() == '$' => {
+                    if let Some(val) = val.take() {
+                        TokenTree::Group(Group::new(Delimiter::None, val))
+                    } else {
+                        return Err(());
+                    }
+                }
+                tt => tt,
+            };
+
+            out.append(tt);
+        }
+
+        Ok(out)
+    }
+
+    if let Some(input) = input {
+        let mut val = Some(val);
+
+        let out = replace_placeholder_impl(input, &mut val)?;
+
+        if val.is_some() {
+            Err(())
+        } else {
+            Ok(out)
+        }
+    } else {
+        Ok(val)
+    }
 }
 
 pub fn dyn_dyn_cast(input: DynDynCastInput) -> TokenStream {
@@ -94,6 +152,7 @@ pub fn dyn_dyn_cast(input: DynDynCastInput) -> TokenStream {
                 base_markers,
                 tgt_primary_trait,
                 tgt_markers,
+                outer_struct,
             } = input_parsed;
 
             let helper_new = match ty {
@@ -102,12 +161,45 @@ pub fn dyn_dyn_cast(input: DynDynCastInput) -> TokenStream {
                 DynDynCastType::Ref => quote!(new_ref),
             };
 
+            if let Some(ref outer_struct) = outer_struct.as_ref() {
+                match replace_placeholder(Some((*outer_struct).clone()), quote!(())) {
+                    Ok(outer_struct) => match syn::parse2::<Type>(outer_struct) {
+                        Ok(_) => {}
+                        Err(err) => {
+                            return err.to_compile_error();
+                        }
+                    },
+                    Err(()) => {
+                        Diagnostic::spanned(
+                            outer_struct.span().unwrap(),
+                            Level::Error,
+                            "outer struct must have exactly one placeholder `$`",
+                        )
+                        .emit();
+
+                        return quote!(unreachable!());
+                    }
+                }
+            }
+
             let check_markers = if !tgt_markers.is_empty() || !base_markers.is_empty() {
+                let impl_base_markers = replace_placeholder(
+                    outer_struct.clone(),
+                    quote!((impl ?Sized + #base_primary_trait #(+ #base_markers)*)),
+                )
+                .unwrap();
+
+                let impl_tgt_markers = replace_placeholder(
+                    outer_struct.clone(),
+                    quote!((impl ?Sized + #base_primary_trait #(+ #tgt_markers)*)),
+                )
+                .unwrap();
+
                 quote!(
                     if false {
                         fn __dyn_dyn_marker_check(
-                            r: &(impl ?Sized + #base_primary_trait #(+ #base_markers)*)
-                        ) -> &(impl ?Sized + #base_primary_trait #(+ #tgt_markers)*) { r }
+                            r: &#impl_base_markers
+                        ) -> &#impl_tgt_markers { r }
 
                         __dyn_dyn_marker_check(::dyn_dyn::internal::DerefHelperEnd::typecheck(&__dyn_dyn_input));
                     }
@@ -126,42 +218,68 @@ pub fn dyn_dyn_cast(input: DynDynCastInput) -> TokenStream {
                 quote!()
             };
 
-            quote!((|__dyn_dyn_input| unsafe {
-                #check_markers
+            let primary_base =
+                replace_placeholder(outer_struct.clone(), quote!((dyn #base_primary_trait)))
+                    .unwrap();
+            let tgt_dyn = replace_placeholder(
+                outer_struct.clone(),
+                quote!((dyn #tgt_primary_trait #(+ #tgt_markers)*)),
+            )
+            .unwrap();
 
-                let __dyn_dyn_table = ::dyn_dyn::internal::DerefHelperEnd::<dyn #base_primary_trait>::get_dyn_dyn_table(&__dyn_dyn_input);
-                if true {
-                    if let ::core::option::Option::Some(__dyn_dyn_metadata) = __dyn_dyn_table.find::<dyn #tgt_primary_trait>() {
-                        #cast_metadata
-                        ::core::result::Result::Ok(::dyn_dyn::internal::DerefHelperEnd::<dyn #base_primary_trait>::downcast_unchecked::<
-                            dyn #tgt_primary_trait #(+ #tgt_markers)*
-                        >(__dyn_dyn_input, __dyn_dyn_metadata))
-                    } else {
-                        ::core::result::Result::Err(::dyn_dyn::internal::DerefHelperEnd::<dyn #base_primary_trait>::into_err(
-                            __dyn_dyn_input
-                        ))
-                    }
-                } else {
+            let constrain_lifetime = {
+                let base_with_lifetime = replace_placeholder(
+                    outer_struct.clone(),
+                    quote!((dyn #base_primary_trait + '__dyn_dyn_life)),
+                )
+                .unwrap();
+                let tgt_with_lifetime = replace_placeholder(
+                    outer_struct,
+                    quote!((dyn #tgt_primary_trait #(+ #tgt_markers)* + '__dyn_dyn_life)),
+                )
+                .unwrap();
+
+                quote!({
                     fn __dyn_dyn_constrain_lifetime<
                         '__dyn_dyn_ref,
                         '__dyn_dyn_life,
-                        T: ::dyn_dyn::DynDyn<'__dyn_dyn_ref, dyn #base_primary_trait + '__dyn_dyn_life>
+                        T: ::dyn_dyn::DynDyn<'__dyn_dyn_ref, #base_with_lifetime>
                     >(
                         _: T
                     ) -> <
-                        T as ::dyn_dyn::DowncastUnchecked<'__dyn_dyn_ref, dyn #base_primary_trait + '__dyn_dyn_life>
-                    >::DowncastResult<dyn #tgt_primary_trait #(+ #tgt_markers)* + '__dyn_dyn_life> {
+                        T as ::dyn_dyn::DowncastUnchecked<'__dyn_dyn_ref, #base_with_lifetime>
+                    >::DowncastResult<#tgt_with_lifetime> {
                         unreachable!()
                     }
 
                     ::core::result::Result::Ok(__dyn_dyn_constrain_lifetime(
-                        ::dyn_dyn::internal::DerefHelperEnd::<dyn #base_primary_trait>::unwrap(__dyn_dyn_input)
+                        ::dyn_dyn::internal::DerefHelperEnd::<#primary_base>::unwrap(__dyn_dyn_input)
                     ))
+                })
+            };
+
+            quote!((|__dyn_dyn_input| unsafe {
+                #check_markers
+
+                let __dyn_dyn_table = ::dyn_dyn::internal::DerefHelperEnd::<#primary_base>::get_dyn_dyn_table(&__dyn_dyn_input);
+                if true {
+                    if let ::core::option::Option::Some(__dyn_dyn_metadata) = __dyn_dyn_table.find::<dyn #tgt_primary_trait>() {
+                        #cast_metadata
+                        ::core::result::Result::Ok(::dyn_dyn::internal::DerefHelperEnd::<#primary_base>::downcast_unchecked::<
+                            #tgt_dyn
+                        >(__dyn_dyn_input, __dyn_dyn_metadata))
+                    } else {
+                        ::core::result::Result::Err(::dyn_dyn::internal::DerefHelperEnd::<#primary_base>::into_err(
+                            __dyn_dyn_input
+                        ))
+                    }
+                } else {
+                    #constrain_lifetime
                 }
             })({
                 use ::dyn_dyn::internal::DerefHelperT;
 
-                ::dyn_dyn::internal::DerefHelper::<dyn #base_primary_trait, _>::#helper_new(#val)
+                ::dyn_dyn::internal::DerefHelper::<#primary_base, _>::#helper_new(#val)
                     .__dyn_dyn_check_dyn_dyn()
                     .__dyn_dyn_check_ref_mut_dyn_dyn()
                     .__dyn_dyn_check_ref_dyn_dyn()

--- a/dyn-dyn/tests/dst_struct.rs
+++ b/dyn-dyn/tests/dst_struct.rs
@@ -1,0 +1,56 @@
+use dyn_dyn::{dyn_dyn_base, dyn_dyn_cast, dyn_dyn_impl, DynDynBase, DynDynTable};
+
+#[dyn_dyn_base]
+trait Base {}
+trait Trait {
+    fn test(&self) -> u32;
+}
+
+struct StructA;
+
+#[dyn_dyn_impl]
+impl Base for StructA {}
+
+struct StructB(u32);
+
+#[dyn_dyn_impl(Trait)]
+impl Base for StructB {}
+impl Trait for StructB {
+    fn test(&self) -> u32 {
+        self.0
+    }
+}
+
+struct DstStruct<T: ?Sized>(u32, T);
+
+unsafe impl<B: ?Sized + DynDynBase> DynDynBase for DstStruct<B> {
+    fn get_dyn_dyn_table(&self) -> DynDynTable {
+        B::get_dyn_dyn_table(&self.1)
+    }
+}
+
+#[test]
+fn test_dst_struct_cast() {
+    assert_eq!(
+        Err(()),
+        dyn_dyn_cast!(Base => Trait [DstStruct<$>], &DstStruct(0, StructA) as &DstStruct<dyn Base>)
+            .map(|t| t.1.test())
+            .map_err(|_| ())
+    );
+    assert_eq!(
+        Ok(1234),
+        dyn_dyn_cast!(Base => Trait [DstStruct<$>], &DstStruct(0, StructB(1234)) as &DstStruct<dyn Base>)
+            .map(|t| t.1.test())
+            .map_err(|_| ())
+    );
+}
+
+#[test]
+fn test_dst_struct_cast_with_markers() {
+    assert_eq!(
+        Ok(1234),
+        dyn_dyn_cast!(Base + Send => Trait + Send [DstStruct<$>], &DstStruct(0, StructB(1234)) as &DstStruct<dyn Base + Send>)
+            .map(|t| t.1.test())
+            .map_err(|_| ())
+    );
+}


### PR DESCRIPTION
Previously, the dyn_dyn_cast! macro always expected that its input had
the base type `dyn Base`. However, when casting DST structs we actually
want to cast with the base type `Struct<dyn Base>`.

In order to support this use-case, a new syntax has been added to
dyn_dyn_cast! that allows the trait object type to be wrapped in a
generic type when performing the cast.

This technically now allows use of dyn-dyn with DST structs, but
requires that the DST struct manually implements the unsafe DynDynBase
trait.

Issue: #3