### PR TITLE
Better document why unsafe code meets the required invariants

### DIFF
--- a/macros/src/base.rs
+++ b/macros/src/base.rs
@@ -54,12 +54,14 @@ pub fn dyn_dyn_base(_args: TokenStream, mut input: ItemTrait) -> TokenStream {
             fn __dyn_dyn_get_table(&self) -> ::dyn_dyn::DynDynTable;
         }
 
+        // SAFETY: This is just a straightforward passthrough, see the SAFETY comment for DynDynImpl impls in dyn_dyn_impl for more details
         unsafe impl #base_trait_impl_generics #base_trait_ident #type_generics for __dyn_dyn_T #where_clause {
             fn __dyn_dyn_get_table(&self) -> ::dyn_dyn::DynDynTable {
                 <Self as ::dyn_dyn::internal::DynDynImpl<dyn #ident #type_generics>>::get_dyn_dyn_table(self)
             }
         }
 
+        // SAFETY: This is just a straightforward passthrough, see the SAFETY comment for DynDynImpl impls in dyn_dyn_impl for more details
         unsafe impl #impl_generics ::dyn_dyn::DynDynBase for dyn #ident #type_generics + '__dyn_dyn_lifetime #where_clause {
             fn get_dyn_dyn_table(&self) -> ::dyn_dyn::DynDynTable {
                 <Self as #base_trait_ident #type_generics>::__dyn_dyn_get_table(self)

--- a/macros/src/impl_block.rs
+++ b/macros/src/impl_block.rs
@@ -79,6 +79,9 @@ pub fn dyn_dyn_impl(args: Punctuated<Type, Token![,]>, input: ItemImpl) -> Token
             ];
         }
 
+        // SAFETY: The returned DynDynTable does not depend on data in self at all, so get_dyn_dyn_table will always return the same table
+        //         as long as the metadata pointer is not changed in an unsafe way. All entries in the table have valid metadata for this
+        //         type since they were retrieved by performing a trivial unsized coercion on a *const Self.
         unsafe impl #impl_generics ::dyn_dyn::internal::DynDynImpl<dyn #trait_> for #self_ty #where_clause {
             fn get_dyn_dyn_table(&self) -> ::dyn_dyn::DynDynTable {
                 ::dyn_dyn::DynDynTable::new(&#table_ident #turbo_tok #type_generics::__TABLE[..])

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,7 +1,7 @@
 //! This crate provides procedural macros meant to be used with the `dyn-dyn` crate. This crate should not be depended upon directly:
 //! instead, the versions of these macros re-exported from the `dyn-dyn` crate itself should be used.
 
-#![forbid(unsafe_code)]
+#![forbid(unsafe_code)] // We generate unsafe code, but don't want to accidentally use unsafe code at compile-time
 #![feature(proc_macro_diagnostic)]
 
 extern crate proc_macro;

--- a/src/fat.rs
+++ b/src/fat.rs
@@ -119,7 +119,8 @@ impl<'a, B: ?Sized + DynDynBase, P: DowncastUnchecked<'a, B> + 'a> DowncastUnche
         self,
         metadata: DynMetadata<D::Root>,
     ) -> Self::DowncastResult<D> {
-        self.ptr.downcast_unchecked(metadata)
+        // SAFETY: Just passing through to the pointer's implementation.
+        unsafe { self.ptr.downcast_unchecked(metadata) }
     }
 }
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -207,7 +207,8 @@ impl<'a, B: ?Sized + DynDynBase, T: DynDyn<'a, B>, E, F: FnOnce(T) -> E> DerefHe
         self,
         metadata: DynMetadata<D::Root>,
     ) -> <Self::Inner as DowncastUnchecked<'a, B>>::DowncastResult<D> {
-        self.0.downcast_unchecked(metadata)
+        // SAFETY: Invariants are passed through
+        unsafe { self.0.downcast_unchecked(metadata) }
     }
 
     fn unwrap(self) -> Self::Inner {

--- a/src/table.rs
+++ b/src/table.rs
@@ -20,7 +20,9 @@ impl AnyDynMetadata {
     ///
     /// This untyped metadata must have originally been constructed by converting a `DynMetadata<T>`.
     pub const unsafe fn downcast<T: DynDynCastTarget + ?Sized>(self) -> DynMetadata<T> {
-        mem::transmute(self.0)
+        // SAFETY: Safety invariants for this fn require that this pointer came from transmuting a DynMetadata<T>, so transmuting it back
+        //         should be safe.
+        unsafe { mem::transmute(self.0) }
     }
 }
 


### PR DESCRIPTION
Previously, there was quite a bit of unsafe code that was missing any `SAFETY` comments to describe why it was correct. Specifically, code in an `unsafe fn` and code generated by the procedural macros. However, some of this unsafe code was quite nontrivial and the ways in which the invariants were upheld was not exactly obvious.

To better document this, the `unsafe_op_in_unsafe_fn` lint has been turned on (which requires `unsafe` blocks even in an `unsafe fn`) and `SAFETY` comments have been added onto all unsafe blocks.