### PR TITLE
Rework UncheckedDowncast

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ fn main() {
 
     assert!(dyn_dyn_cast!(BaseTrait => ExposedTrait, &s).is_ok());
     assert!(dyn_dyn_cast!(mut BaseTrait => ExposedTrait, &mut s).is_ok());
+
+    #[cfg(feature = "alloc")]
     assert!(dyn_dyn_cast!(move BaseTrait => ExposedTrait, Box::new(s)).is_ok());
 }
 ```

--- a/macros/src/cast.rs
+++ b/macros/src/cast.rs
@@ -243,12 +243,12 @@ pub fn dyn_dyn_cast(input: DynDynCastInput) -> TokenStream {
                     fn __dyn_dyn_constrain_lifetime<
                         '__dyn_dyn_ref,
                         '__dyn_dyn_life,
-                        T: ::dyn_dyn::DynDyn<'__dyn_dyn_ref, #base_with_lifetime>
+                        T: ::dyn_dyn::internal::DynDynConstrainLifetime<'__dyn_dyn_ref, #base_with_lifetime>
                     >(
                         _: T
                     ) -> <
-                        T as ::dyn_dyn::DowncastUnchecked<'__dyn_dyn_ref, #base_with_lifetime>
-                    >::DowncastResult<#tgt_with_lifetime> {
+                        T as ::dyn_dyn::internal::DynDynConstrainLifetime<'__dyn_dyn_ref, #base_with_lifetime>
+                    >::Result<#tgt_with_lifetime> {
                         unreachable!()
                     }
 

--- a/src/fat.rs
+++ b/src/fat.rs
@@ -110,10 +110,10 @@ unsafe impl<B: ?Sized + DynDynBase, P: GetDynDynTable<B>> GetDynDynTable<B> for 
     }
 }
 
-impl<'a, B: ?Sized + DynDynBase, P: DowncastUnchecked<'a, B> + 'a> DowncastUnchecked<'a, B>
+impl<'a, B: ?Sized + DynDynBase, P: DowncastUnchecked<'a> + 'a> DowncastUnchecked<'a>
     for DynDynFat<B, P>
 {
-    type DowncastResult<D: ?Sized + 'a> = <P as DowncastUnchecked<'a, B>>::DowncastResult<D>;
+    type DowncastResult<D: ?Sized + 'a> = <P as DowncastUnchecked<'a>>::DowncastResult<D>;
 
     unsafe fn downcast_unchecked<D: ?Sized + Pointee>(
         self,

--- a/src/fat.rs
+++ b/src/fat.rs
@@ -1,11 +1,11 @@
-use crate::{DowncastUnchecked, DynDynBase, DynDynCastTarget, DynDynTable, GetDynDynTable};
+use crate::{DowncastUnchecked, DynDynBase, DynDynTable, GetDynDynTable};
 use core::cmp::Ordering;
 use core::fmt::{self, Display, Pointer};
 use core::hash::{Hash, Hasher};
 use core::marker::{PhantomData, Unsize};
 use core::ops::CoerceUnsized;
 use core::ops::{Deref, DerefMut};
-use core::ptr::{self, DynMetadata};
+use core::ptr::{self, Pointee};
 use stable_deref_trait::{CloneStableDeref, StableDeref};
 
 /// A fat pointer to an object that can be downcast via the base trait object `B`.
@@ -115,9 +115,9 @@ impl<'a, B: ?Sized + DynDynBase, P: DowncastUnchecked<'a, B> + 'a> DowncastUnche
 {
     type DowncastResult<D: ?Sized + 'a> = <P as DowncastUnchecked<'a, B>>::DowncastResult<D>;
 
-    unsafe fn downcast_unchecked<D: ?Sized + DynDynCastTarget>(
+    unsafe fn downcast_unchecked<D: ?Sized + Pointee>(
         self,
-        metadata: DynMetadata<D::Root>,
+        metadata: <D as Pointee>::Metadata,
     ) -> Self::DowncastResult<D> {
         // SAFETY: Just passing through to the pointer's implementation.
         unsafe { self.ptr.downcast_unchecked(metadata) }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -4,8 +4,7 @@ use crate::{
 };
 use core::marker::{PhantomData, Unsize};
 use core::ops::{Deref, DerefMut};
-use core::ptr::DynMetadata;
-use core::ptr::NonNull;
+use core::ptr::{DynMetadata, NonNull, Pointee};
 use stable_deref_trait::StableDeref;
 
 #[allow(clippy::missing_safety_doc)] // This module is marked doc(hidden)
@@ -40,9 +39,9 @@ pub trait DerefHelperEnd<'a, B: ?Sized + DynDynBase> {
     type Err;
 
     fn get_dyn_dyn_table(&self) -> DynDynTable;
-    unsafe fn downcast_unchecked<D: ?Sized + DynDynCastTarget>(
+    unsafe fn downcast_unchecked<D: ?Sized + Pointee>(
         self,
-        metadata: DynMetadata<D::Root>,
+        metadata: <D as Pointee>::Metadata,
     ) -> <Self::Inner as DowncastUnchecked<'a, B>>::DowncastResult<D>;
     fn unwrap(self) -> Self::Inner;
     fn into_err(self) -> Self::Err;
@@ -165,9 +164,9 @@ impl<'a, B: ?Sized + DynDynBase, T: DynDyn<'a, B>> DerefHelperEnd<'a, B> for Der
         unreachable!()
     }
 
-    unsafe fn downcast_unchecked<D: ?Sized + DynDynCastTarget>(
+    unsafe fn downcast_unchecked<D: ?Sized + Pointee>(
         self,
-        _: DynMetadata<D::Root>,
+        _: <D as Pointee>::Metadata,
     ) -> <Self::Inner as DowncastUnchecked<'a, B>>::DowncastResult<D> {
         unreachable!()
     }
@@ -203,9 +202,9 @@ impl<'a, B: ?Sized + DynDynBase, T: DynDyn<'a, B>, E, F: FnOnce(T) -> E> DerefHe
         self.0.get_dyn_dyn_table()
     }
 
-    unsafe fn downcast_unchecked<D: ?Sized + DynDynCastTarget>(
+    unsafe fn downcast_unchecked<D: ?Sized + Pointee>(
         self,
-        metadata: DynMetadata<D::Root>,
+        metadata: <D as Pointee>::Metadata,
     ) -> <Self::Inner as DowncastUnchecked<'a, B>>::DowncastResult<D> {
         // SAFETY: Invariants are passed through
         unsafe { self.0.downcast_unchecked(metadata) }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@ pub use dyn_dyn_macros::dyn_dyn_base;
 ///     dyn_dyn_cast!(Base + Send => Trait + Send, r)
 /// }
 ///
+/// # #[cfg(feature = "alloc")]
 /// fn downcast_box(r: Box<dyn Base>) -> Result<Box<dyn Trait>, Box<dyn Base>> {
 ///     dyn_dyn_cast!(move Base => Trait, r)
 /// }
@@ -82,6 +83,7 @@ pub use dyn_dyn_macros::dyn_dyn_base;
 ///     assert!(downcast(&s).is_ok());
 ///     assert!(downcast_mut(&mut s).is_ok());
 ///     assert!(downcast_with_auto(&s).is_ok());
+///     # #[cfg(feature = "alloc")]
 ///     assert!(downcast_box(Box::new(s)).is_ok());
 /// }
 /// ```

--- a/tests/basics.rs
+++ b/tests/basics.rs
@@ -139,26 +139,42 @@ fn test_from_alloc() {
     }
 
     let mut test_box = Box::new(TestStruct);
+    let box_ptr = &*test_box as *const _;
 
     assert_eq!(
-        Ok(&*test_box as *const _),
+        Ok(box_ptr),
         dyn_dyn_cast!(Base => TestTrait, &test_box)
             .map(|t: &dyn TestTrait| t.test())
             .map_err(|_| ())
     );
 
     assert_eq!(
-        Ok(&mut *test_box as *const _),
+        Ok(box_ptr),
         dyn_dyn_cast!(mut Base => TestTrait, &mut test_box)
             .map(|t: &mut dyn TestTrait| t.test())
             .map_err(|_| ())
     );
 
+    assert_eq!(
+        Ok(box_ptr),
+        dyn_dyn_cast!(move Base => TestTrait, test_box)
+            .map(|t: Box<dyn TestTrait>| t.test())
+            .map_err(|_| ())
+    );
+
     let test_rc = Rc::new(TestStruct);
+    let rc_ptr = &*test_rc as *const _;
 
     assert_eq!(
-        Ok(&*test_rc as *const _),
+        Ok(rc_ptr),
         dyn_dyn_cast!(Base => TestTrait, &test_rc)
+            .map(|t| t.test())
+            .map_err(|_| ())
+    );
+
+    assert_eq!(
+        Ok(rc_ptr),
+        dyn_dyn_cast!(move Base => TestTrait, test_rc)
             .map(|t| t.test())
             .map_err(|_| ())
     );

--- a/tests/basics.rs
+++ b/tests/basics.rs
@@ -1,6 +1,5 @@
 use dyn_dyn::{dyn_dyn_base, dyn_dyn_cast, dyn_dyn_impl};
 use std::fmt;
-use std::rc::Rc;
 
 #[test]
 fn test_vtable_correct() {
@@ -119,8 +118,11 @@ fn test_data_pointer_correct() {
     );
 }
 
+#[cfg(feature = "alloc")]
 #[test]
 fn test_from_alloc() {
+    use std::rc::Rc;
+
     #[dyn_dyn_base]
     trait Base {}
     trait TestTrait {
@@ -262,4 +264,24 @@ fn test_temporaries_extended() {
 
     assert!(dyn_dyn_cast!(Base => Trait, &return_temporary() as &dyn Base).is_ok());
     assert!(dyn_dyn_cast!(mut Base => Trait, &mut return_temporary() as &mut dyn Base).is_ok());
+}
+
+#[cfg(feature = "alloc")]
+#[test]
+fn test_static_lifetime_on_base() {
+    #[dyn_dyn_base]
+    trait Base: 'static {}
+    trait Trait {}
+
+    struct TestStruct;
+
+    #[dyn_dyn_impl(Trait)]
+    impl Base for TestStruct {}
+    impl Trait for TestStruct {}
+
+    let mut boxed = Box::new(TestStruct);
+
+    assert!(dyn_dyn_cast!(Base => Trait, &boxed).is_ok());
+    assert!(dyn_dyn_cast!(mut Base => Trait, &mut boxed).is_ok());
+    assert!(dyn_dyn_cast!(move Base => Trait, boxed).is_ok());
 }


### PR DESCRIPTION
This PR significantly reworks how the `UncheckedDowncast` trait works by allowing it to be used for all pointee types (not just those that provably have trait object metadata) and removing the unused `B` generic parameter for the base trait. This should make it easier to implement `UncheckedDowncast` for certain types, especially those that represent pointers to a trait object embedded in a DST struct.