### PR TITLE
Remove reliance on the `effects' Nightly feature

### DIFF
--- a/macros/src/impl_block.rs
+++ b/macros/src/impl_block.rs
@@ -77,7 +77,7 @@ pub fn dyn_dyn_impl(args: Punctuated<Type, Token![,]>, input: ItemImpl) -> Token
                 impl #impl_generics __dyn_dyn_DynTable #type_generics #where_clause {
                     pub const __TABLE: [::dyn_dyn::DynDynTableEntry; #num_table_entries] = [
                         #(
-                            ::dyn_dyn::DynDynTableEntry::new::<#self_ty, dyn #convert_tys>()
+                            ::dyn_dyn::DynDynTableEntry::new::<#self_ty, dyn #convert_tys, _>()
                         ),*
                     ];
                 }

--- a/src/cast_target.rs
+++ b/src/cast_target.rs
@@ -1,8 +1,6 @@
-use core::marker::Unsize;
 use core::ptr::{self, DynMetadata, NonNull, Pointee};
 
 /// A type whose pointer metadata can be stored in a [`DynDynTable`](crate::DynDynTable).
-#[const_trait]
 pub trait DynDynCastTarget: private::Sealed {
     /// The root type that the trait object metadata is for.
     type Root: ?Sized;
@@ -12,12 +10,9 @@ pub trait DynDynCastTarget: private::Sealed {
 
     /// Combines a data pointer with the provided metadata to produce a fat pointer.
     fn ptr_from_parts(data: NonNull<()>, meta: DynMetadata<Self::Root>) -> NonNull<Self>;
-
-    /// Gets the metadata that would be used for an object of concrete type `U` when cast to this type.
-    fn meta_for_ty<U: Unsize<Self>>() -> DynMetadata<Self::Root>;
 }
 
-impl<M: ?Sized, T: Pointee<Metadata = DynMetadata<M>> + ?Sized> const DynDynCastTarget for T {
+impl<M: ?Sized, T: Pointee<Metadata = DynMetadata<M>> + ?Sized> DynDynCastTarget for T {
     type Root = M;
 
     fn ptr_into_parts(ptr: NonNull<Self>) -> (NonNull<()>, DynMetadata<M>) {
@@ -27,10 +22,6 @@ impl<M: ?Sized, T: Pointee<Metadata = DynMetadata<M>> + ?Sized> const DynDynCast
     fn ptr_from_parts(data: NonNull<()>, meta: DynMetadata<M>) -> NonNull<Self> {
         // SAFETY: If data is not null, then the result of attaching metadata to it is not null either
         unsafe { NonNull::new_unchecked(ptr::from_raw_parts_mut(data.as_ptr(), meta)) }
-    }
-
-    fn meta_for_ty<U: Unsize<Self>>() -> DynMetadata<M> {
-        ptr::metadata(ptr::null::<U>() as *const Self)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,6 @@
 #![feature(const_type_id)]
 #![cfg_attr(feature = "dynamic-names", feature(const_type_name))]
 #![feature(doc_auto_cfg)]
-#![feature(effects)]
 #![feature(ptr_metadata)]
 #![feature(unsize)]
 


### PR DESCRIPTION
Previously, DynDynCastTarget was marked with #[const_trait] so that it could be used in the construction of a DynDynTableEntry. However, the Nightly feature that makes this possible is being significantly reworked in newer versions of Rust. Because of this, its usage here no longer actually works.

In order to remedy this, the DynDynTableEntry::new method now directly depends on an implementation of the Pointee trait and will no longer use DynDynCastTarget. This allows it to still work in a const context without needing to rely on #[const_trait].