### PR TITLE
Further restrict the trait bounds allowed by dyn_dyn_cast!

### DIFF
--- a/macros/src/cast.rs
+++ b/macros/src/cast.rs
@@ -63,6 +63,7 @@ struct DynDynCastProcessedInput {
 #[derive(Debug, Clone, Copy)]
 enum Error {
     LifetimesNotAllowedInCast,
+    BaseMarkerTraitsNotAllowed,
 }
 
 fn split_trait_bounds(
@@ -91,6 +92,10 @@ fn split_trait_bounds(
 
 fn process_input(input: &DynDynCastInput) -> Result<DynDynCastProcessedInput, (Span, Error)> {
     let (base_primary_trait, base_markers) = split_trait_bounds(&input.base_traits)?;
+    if let Some(base_marker) = base_markers.first() {
+        return Err((base_marker.span(), Error::BaseMarkerTraitsNotAllowed));
+    }
+
     let (tgt_primary_trait, tgt_markers) = split_trait_bounds(&input.target_traits)?;
 
     Ok(DynDynCastProcessedInput {
@@ -325,11 +330,21 @@ pub fn dyn_dyn_cast(input: DynDynCastInput) -> TokenStream {
             }))
         }
         Err((span, err)) => {
-            let err = match err {
-                Error::LifetimesNotAllowedInCast => "Explicit lifetimes are not allowed in dyn_dyn_cast!",
+            let (err, note) = match err {
+                Error::LifetimesNotAllowedInCast => ("Explicit lifetimes are not allowed in dyn_dyn_cast!", None),
+                Error::BaseMarkerTraitsNotAllowed => (
+                    "Marker traits are not allowed on the base trait in a dyn_dyn_cast!",
+                    Some("this used to be allowed prior to dyn-dyn 0.2 to cast to targets with marker traits, but is liable to cause UB in the future due to https://github.com/rust-lang/rust/issues/127323")
+                ),
             };
 
-            Diagnostic::spanned(span.unwrap(), Level::Error, err).emit();
+            let mut d = Diagnostic::spanned(span.unwrap(), Level::Error, err);
+
+            if let Some(note) = note {
+                d = d.note(note);
+            }
+
+            d.emit();
 
             quote!(unreachable!())
         }


### PR DESCRIPTION
This PR makes a couple changes to the trait bounds allowed by `dyn_dyn_cast!` to allow cleaning up after the removal of the ability to use auto marker traits:

- Any explicit lifetime bounds are now completely disallowed. This isn't generally a big deal since the output lifetime is always inferred to be the same as the input lifetime, but it was keeping some otherwise dead code alive and never really worked 100% properly.
- Marker traits are now also forbidden for the base trait, since they were never really useful outside of allowing marker traits on the target trait.